### PR TITLE
Update 40-user-api.tex

### DIFF
--- a/docs/libflame/40-user-api.tex
+++ b/docs/libflame/40-user-api.tex
@@ -6983,7 +6983,7 @@ void FLASH_Gemv( FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, FLA_Obj x,
 \index{FLAME/C functions!\flagemvns}
 \index{FLASH functions!\flashgemvns}
 \purpose{
-Perform one of the following general matrix-matrix multiplication ({\sc gemv})
+Perform one of the following general matrix-vector multiplication ({\sc gemv})
 operations:
 \begin{eqnarray*}
 y & := & \beta y + \alpha A x \\


### PR DESCRIPTION
Details:
- There was a typo that called gemv a matrix-matrix multiply. Changed to matrix-vector.
