### PR TITLE
build: Fixed Makefile for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,10 +371,6 @@ endif
 
 # --- Static library archiver rules for libflame ---
 $(MK_ALL_FLAMEC_LIB): $(MK_ALL_FLAMEC_OBJS)
-define EOL
-
-
-endef
 ifeq ($(FLA_ENABLE_VERBOSE_MAKE_OUTPUT),yes)
 ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
 	@$(eval ar_args:=)


### PR DESCRIPTION
- Makefile had a define statement messing up with
  a target making it fail instantly on "make".
