### PR TITLE
Use markdown in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-
-libflame library
-README
----
-
-Thank you for deciding to try out the libflame library!
+# libflame library
 
 libflame is a portable library for dense matrix computations, providing
 much of the functionality present in LAPACK. In fact, libflame includes
@@ -30,18 +25,18 @@ source. You may also find a nightly build of the document here:
 You can keep in touch with developers and other users of the project by
 joining the following mailing list:
 
-  o libflame-discuss - http://groups.google.com/group/libflame-discuss
+ - libflame-discuss - http://groups.google.com/group/libflame-discuss
     Please join and post to this mailing list if you have general questions
     or feedback regarding libflame.
 
-  o (NOTE: We do not yet have a developer's mailing list. For now,
+ -  (NOTE: We do not yet have a developer's mailing list. For now,
     developers and those with developer-related questions can simply post
     to libflame-discuss.
 
 Also, please read the LICENSE file for information on copying and
 distributing this software.
 
-Thanks again for your interest in libflame!
+Thanks for your interest in libflame!
 
 Regards,
 


### PR DESCRIPTION
This converts the readme to markdown as it is done for flame/blis as it is much better rendered on Github. 

I actually went to the Github home page yesteday and missed the main purpose of this library because  the title

> High-performance object-based library for DLA computations 

was somewhat abstract and left me wondering, the readme was in such tiny font that I must have stopped reading before the sentence that could have explained it to me,

> libFLAME is a portable library for dense matrix computations, providing much of the functionality present in LAPACK

(the key word there was "(improved) LAPACK" in my case)

Instead I went straight to the website and there again,

> libFLAME is a high performance dense linear algebra library that is the result of the FLAME methodology for systematically developing dense linear algebra libraries. The FLAME methodology is radically different from the LINPACK/LAPACK approach that dates back to the 1970s.

might be accurate but it doesn't actually say what libflame is in relationship to BLAS/LAPACK.

So this PR aims to improve the user experience a bit.

The rendered version can be seen at https://github.com/flame/libflame/blob/be2dbe97a5c723926ab6eef8512d587e207d128b/README.md