### PR TITLE
Fixes for include lines

### DIFF
--- a/src/map/lapack2flamec/f2c/install/util/io/arith.h
+++ b/src/map/lapack2flamec/f2c/install/util/io/arith.h
@@ -24,7 +24,7 @@ use or performance of this software.
 #ifndef F2C_ARITH_H
 #define F2C_ARITH_H
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <math.h>
 
 #ifdef _MSC_VER

--- a/src/map/lapack2flamec/f2c/install/util/io/close.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/close.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 

--- a/src/map/lapack2flamec/f2c/install/util/io/dolio.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/dolio.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 

--- a/src/map/lapack2flamec/f2c/install/util/io/endfile.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/endfile.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 

--- a/src/map/lapack2flamec/f2c/install/util/io/err.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/err.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdlib.h>
 #if defined(_MSC_VER) || defined(__MINGW32__)
 # include <io.h>

--- a/src/map/lapack2flamec/f2c/install/util/io/f2c.h
+++ b/src/map/lapack2flamec/f2c/install/util/io/f2c.h
@@ -34,9 +34,9 @@ use or performance of this software.
 #include <math.h>
 #include <string.h>
 #ifdef _MSC_VER
-# include <f2c_types_win.h>
+# include "f2c_types_win.h"
 #else
-# include <f2c_types.h>
+# include "f2c_types.h"
 #endif
 
 #ifdef __cplusplus
@@ -308,7 +308,7 @@ void z_sqrt(doublecomplex *r, doublecomplex *z);
 
 #ifndef F2C_NO_INLINE_H
 # if defined(__GNUC__)
-#  include <f2c_inline.h>
+#  include "f2c_inline.h"
 # endif
 #endif
 

--- a/src/map/lapack2flamec/f2c/install/util/io/fio.h
+++ b/src/map/lapack2flamec/f2c/install/util/io/fio.h
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/map/lapack2flamec/f2c/install/util/io/fmt.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/fmt.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/fmtlib.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/fmtlib.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 /*	@(#)fmtlib.c	1.2	*/
 #define MAXINTLENGTH 23
 

--- a/src/map/lapack2flamec/f2c/install/util/io/lread.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/lread.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <ctype.h>
 #include "f2c.h"
 #include "fio.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/lwrite.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/lwrite.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/open.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/open.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdlib.h>
 #include <string.h>
 #ifndef NON_UNIX_STDIO

--- a/src/map/lapack2flamec/f2c/install/util/io/rdfmt.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/rdfmt.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdlib.h>
 #include <ctype.h>
 #include "f2c.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/rsfe.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/rsfe.c
@@ -22,7 +22,7 @@ use or performance of this software.
 ****************************************************************/
 
 /* read sequential formatted external */
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/sfe.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/sfe.c
@@ -22,7 +22,7 @@ use or performance of this software.
 ****************************************************************/
 
 /* sequential formatted external common routines*/
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 

--- a/src/map/lapack2flamec/f2c/install/util/io/sig_die.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/sig_die.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>

--- a/src/map/lapack2flamec/f2c/install/util/io/util.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/util.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 

--- a/src/map/lapack2flamec/f2c/install/util/io/wref.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/wref.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/map/lapack2flamec/f2c/install/util/io/wrtfmt.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/wrtfmt.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/wsfe.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/wsfe.c
@@ -22,7 +22,7 @@ use or performance of this software.
 ****************************************************************/
 
 /*write sequential formatted external*/
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/src/map/lapack2flamec/f2c/install/util/io/wsle.c
+++ b/src/map/lapack2flamec/f2c/install/util/io/wsle.c
@@ -21,7 +21,7 @@ other tortious action, arising out of or in connection with the
 use or performance of this software.
 ****************************************************************/
 
-#include <f2c_config.h>
+#include "f2c_config.h"
 #include <string.h>
 #include "f2c.h"
 #include "fio.h"


### PR DESCRIPTION
Compiling fails if `--enable-builtin-blas` is specified during configure because of incorrect brackets (`<>` instead of `""` for local headers). May be it worth to check also in other files too.