### PR TITLE
Fixes ARG_MAX hack for shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,8 @@ endif
 $(LIBFLAME_SO_PATH): $(MK_ALL_FLAMEC_OBJS)
 ifeq ($(ENABLE_VERBOSE),yes)
 ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
-	$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ @$(AR_OBJ_LIST_FILE)
+	$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+	$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A)
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
 #	the list of prerequisites.
@@ -571,7 +572,8 @@ endif
 else
 	@echo "Dynamically linking $@"
 ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
-	@$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ @$(AR_OBJ_LIST_FILE)
+	@$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+	@$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A)
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
 #	the list of prerequisites.


### PR DESCRIPTION
Details:
- `collect2` internally calls execvp, which may result in
  `collect2: fatal error: execvp: Argument list too long` when
  building shared library, when when the list of object files are passed to
  the linker in a text file. This fix instead creates a `libflame.a` file using
  the hack for static library, and then pass the `libflame.a` to the linker
  to create a shared library.
- Fixes issue https://github.com/flame/libflame/issues/29