### PR TITLE
Fixes ARG_MAX hack for shared library on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,11 @@ $(LIBFLAME_SO_PATH): $(MK_ALL_FLAMEC_OBJS)
 ifeq ($(ENABLE_VERBOSE),yes)
 ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
 	$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+ifeq ($(OS_NAME),Darwin)
 	$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A)
+else
+	$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive
+endif
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
 #	the list of prerequisites.
@@ -573,7 +577,11 @@ else
 	@echo "Dynamically linking $@"
 ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
 	@$(CAT) $(AR_OBJ_LIST_FILE) | xargs -n$(AR_CHUNK_SIZE) $(AR) $(ARFLAGS) $(LIBFLAME_A)
+ifeq ($(OS_NAME),Darwin)
 	@$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A)
+else
+	@$(LINKER) $(SOFLAGS) $(LDFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive
+endif
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
 #	the list of prerequisites.


### PR DESCRIPTION
Details:
- `-force_load` works on macOS but not on linux with GNU ld.
  `--whole-archive,libframe.a,--no-whole-archive` should be used on
  Linux instead. (https://github.com/flame/libflame/issues/29)