### PR TITLE
Makefile: use separate whole-archive/no-whole-archive to fix build with Cray compiler wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,7 +566,7 @@ ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
 ifeq ($(OS_NAME),Darwin)
 	$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A) $(LDFLAGS)
 else
-	$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive $(LDFLAGS)
+	$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive $(LIBFLAME_A) -Wl,--no-whole-archive $(LDFLAGS)
 endif
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in
@@ -580,7 +580,7 @@ ifeq ($(FLA_ENABLE_MAX_ARG_LIST_HACK),yes)
 ifeq ($(OS_NAME),Darwin)
 	@$(LINKER) $(SOFLAGS) -o $@ -Wl,-force_load,$(LIBFLAME_A) $(LDFLAGS)
 else
-	@$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive,$(LIBFLAME_A),--no-whole-archive $(LDFLAGS)
+	@$(LINKER) $(SOFLAGS) -o $@ -Wl,--whole-archive $(LIBFLAME_A) -Wl,--no-whole-archive $(LDFLAGS)
 endif
 else
 #	NOTE: Can't use $^ automatic variable as long as $(AR_OBJ_LIST_FILE) is in


### PR DESCRIPTION
see the issue reported here against AMDs libflame fork: https://github.com/spack/spack/issues/24210
