### PR TITLE
Add HIP support to libflame (part 1)

### DIFF
--- a/build/FLA_config.h.in
+++ b/build/FLA_config.h.in
@@ -50,6 +50,9 @@
 /* Determines whether GPU-specific blocks of code should be compiled. */
 #undef FLA_ENABLE_GPU
 
+/* Determines whether HIP-specific blocks of code should be compiled. */
+#undef FLA_ENABLE_HIP
+
 /* Determines whether to enable internal runtime consistency checks of
    function parameters and return values. */
 #undef FLA_ENABLE_INTERNAL_ERROR_CHECKING

--- a/build/ac-macros/fla_check_enable_hip.m4
+++ b/build/ac-macros/fla_check_enable_hip.m4
@@ -1,0 +1,63 @@
+AC_DEFUN([FLA_CHECK_ENABLE_HIP],
+[
+	dnl Tell the user we're checking whether to enable the option.
+	AC_MSG_CHECKING([whether user requested HIP extensions])
+	
+	dnl Determine whether the user gave the --enable-<option> or
+	dnl --disable-<option>. If so, then run the first snippet of code;
+	dnl otherwise, run the second code block.
+	AC_ARG_ENABLE([hip],
+	              AC_HELP_STRING([--enable-hip],[Enable code that takes advantage of HIPs when performing certain computations. If enabled, SuperMatrix must also be enabled. Note that this option is experimental. (Disabled by default.)]),
+	[
+		dnl If any form of the option is given, handle each case.
+		if test "$enableval" = "no" ; then
+
+			dnl User provided --enable-<option>=no or --disable-<option>.
+			fla_enable_hip=no
+
+		elif test "$enableval" = "yes" ; then
+
+			dnl User provided --enable-<option>=yes or --enable-<option>.
+			fla_enable_hip=yes
+		else
+
+			dnl We don't need an else branch because the configure script
+			dnl should detect whether the user provided an unexpected argument
+			dnl with the option.
+			AC_MSG_ERROR([[Reached unreachable branch in FLA_CHECK_ENABLE_HIP!]])
+		fi
+	],
+	[
+		dnl User did not specify whether to enable or disable the option.
+		dnl Default behavior is to disable the option.
+		fla_enable_hip=no
+	]
+	)
+
+	dnl Now act according to whether the option was requested.
+	if   test "$fla_enable_hip" = "yes" ; then
+		
+		dnl Output the result.
+		AC_MSG_RESULT([yes])
+		
+		dnl Define the macro.
+		AC_DEFINE(FLA_ENABLE_HIP,1,
+		          [Determines whether HIP-specific blocks of code should be compiled.])
+		
+	elif test "$fla_enable_hip" = "no" ; then
+		
+		dnl Output the result.
+		AC_MSG_RESULT([no])
+		
+	else
+
+		dnl Only "yes" and "no" are accepted, so this block is empty.
+		AC_MSG_ERROR([[Reached unreachable branch in FLA_CHECK_ENABLE_HIP!]])
+
+	fi
+	
+	dnl Substitute the output variable.
+	AC_SUBST(fla_enable_hip)
+
+])
+

--- a/build/ac-macros/fla_require_not_hip_and_gpu_enabled.m4
+++ b/build/ac-macros/fla_require_not_hip_and_gpu_enabled.m4
@@ -1,0 +1,15 @@
+AC_DEFUN([FLA_REQUIRE_NOT_HIP_AND_GPU_ENABLED],
+[
+	AC_REQUIRE([FLA_CHECK_ENABLE_GPU])
+	AC_REQUIRE([FLA_CHECK_ENABLE_HIP])
+
+	dnl Make sure the user did not request an invalid combination of
+	dnl acceleration options.
+
+	dnl User enabled both GPU and HIP 
+	if test "$fla_enable_gpu" = "yes" ; then
+		if test "$fla_enable_hip" = "yes" ; then
+			AC_MSG_ERROR([Configuring libflame to enable GPU and HIP support is not allowed. Please adjust your configure options accordingly and then re-run configure.],[1])
+		fi
+	fi
+])

--- a/build/ac-macros/fla_require_supermatrix_enabled.m4
+++ b/build/ac-macros/fla_require_supermatrix_enabled.m4
@@ -3,6 +3,7 @@ AC_DEFUN([FLA_REQUIRE_SUPERMATRIX_ENABLED],
 	AC_REQUIRE([FLA_CHECK_ENABLE_SUPERMATRIX])
 	AC_REQUIRE([FLA_CHECK_ENABLE_MULTITHREADING])
 	AC_REQUIRE([FLA_CHECK_ENABLE_GPU])
+	AC_REQUIRE([FLA_CHECK_ENABLE_HIP])
 
 	dnl Make sure the user did not request an invalid combination of
 	dnl parallelization options.
@@ -11,6 +12,13 @@ AC_DEFUN([FLA_REQUIRE_SUPERMATRIX_ENABLED],
 	if test "$fla_enable_gpu" = "yes" ; then
 		if test "$fla_enable_supermatrix" = "no" ; then
 			AC_MSG_ERROR([Configuring libflame to enable GPU support without also enabling SuperMatrix is not allowed. GPU utilization requires that SuperMatrix be enabled. Please adjust your configure options accordingly and then re-run configure.],[1])
+		fi
+	fi
+
+	dnl Scenario 2: User wants HIP support but forgot to enable SM.
+	if test "$fla_enable_hip" = "yes" ; then
+		if test "$fla_enable_supermatrix" = "no" ; then
+			AC_MSG_ERROR([Configuring libflame to enable HIP support without also enabling SuperMatrix is not allowed. HIP utilization requires that SuperMatrix be enabled. Please adjust your configure options accordingly and then re-run configure.],[1])
 		fi
 	fi
 ])

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -126,6 +126,11 @@ endif
 CFLAGS       := $(strip $(CDBGFLAGS) $(COPTFLAGS) $(CVECFLAGS) $(CWARNFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS))
 CFLAGS_NOOPT := $(strip $(CDBGFLAGS) $(CWARNFLAGS) $(CMISCFLAGS) $(CPPROCFLAGS))
 
+ifeq (@fla_enable_hip@, yes)
+CFLAGS       := -D__HIP_PLATFORM_AMD__=1 -I/opt/rocm/include $(CFLAGS)
+CFLAGS_NOOPT := -D__HIP_PLATFORM_AMD__=1 -I/opt/rocm/include $(CFLAGS_NOOPT)
+endif
+
 # If the user provided his own CFLAGS, allow them to override our own.
 # *** Notice that wo do not also modify the 'no optimization' set of flags.
 #     We do this to avoid potential numerical disruption of routines such
@@ -158,7 +163,9 @@ else
 LDFLAGS      := @fla_c_prof_flags@ @LDFLAGS@ @FLIBS@
 endif
 endif
-
+ifeq (@fla_enable_hip@, yes)
+LDFLAGS      := -L/opt/rocm/lib -lrocblas -lamdhip64 $(LDFLAGS)
+endif
 
 
 # end of ifndef CONFIG_MK_INCLUDED conditional block

--- a/build/post-configure.sh.in
+++ b/build/post-configure.sh.in
@@ -67,6 +67,9 @@ echo ""
 echo "Enable GPU support.............................. : @fla_enable_gpu@"
 
 echo ""
+echo "Enable HIP support.............................. : @fla_enable_hip@"
+
+echo ""
 echo "Enable SCC support.............................. : @fla_enable_scc@"
 
 echo ""

--- a/configure
+++ b/configure
@@ -662,6 +662,7 @@ fla_enable_memory_alignment
 fla_vector_intrinsic_type
 fla_enable_vector_intrinsics
 fla_c_sse_flags
+fla_enable_hip
 fla_enable_gpu
 fla_enable_supermatrix
 fla_multithreading_model
@@ -779,6 +780,7 @@ enable_blas3_front_end_cntl_trees
 enable_multithreading
 enable_supermatrix
 enable_gpu
+enable_hip
 enable_vector_intrinsics
 enable_memory_alignment
 enable_ldim_alignment
@@ -1526,6 +1528,10 @@ Optional Features:
                           and parallel execution system. (Disabled by
                           default.)
   --enable-gpu            Enable code that takes advantage of GPUs when
+                          performing certain computations. If enabled,
+                          SuperMatrix must also be enabled. Note that this
+                          option is experimental. (Disabled by default.)
+  --enable-hip            Enable code that takes advantage of HIPs when
                           performing certain computations. If enabled,
                           SuperMatrix must also be enabled. Note that this
                           option is experimental. (Disabled by default.)
@@ -6688,6 +6694,58 @@ $as_echo "no" >&6; }
 
 
 
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether user requested HIP extensions" >&5
+$as_echo_n "checking whether user requested HIP extensions... " >&6; }
+
+				# Check whether --enable-hip was given.
+if test "${enable_hip+set}" = set; then :
+  enableval=$enable_hip;
+				if test "$enableval" = "no" ; then
+
+						fla_enable_hip=no
+
+		elif test "$enableval" = "yes" ; then
+
+						fla_enable_hip=yes
+		else
+
+												as_fn_error $? "Reached unreachable branch in FLA_CHECK_ENABLE_HIP!" "$LINENO" 5
+		fi
+
+else
+
+						fla_enable_hip=no
+
+
+fi
+
+
+		if   test "$fla_enable_hip" = "yes" ; then
+
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+
+$as_echo "#define FLA_ENABLE_HIP 1" >>confdefs.h
+
+
+	elif test "$fla_enable_hip" = "no" ; then
+
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+	else
+
+				as_fn_error $? "Reached unreachable branch in FLA_CHECK_ENABLE_HIP!" "$LINENO" 5
+
+	fi
+
+
+
+
+
+
+
 
 
 
@@ -6696,6 +6754,24 @@ $as_echo "no" >&6; }
 		if test "$fla_enable_gpu" = "yes" ; then
 		if test "$fla_enable_supermatrix" = "no" ; then
 			as_fn_error 1 "Configuring libflame to enable GPU support without also enabling SuperMatrix is not allowed. GPU utilization requires that SuperMatrix be enabled. Please adjust your configure options accordingly and then re-run configure." "$LINENO" 5
+		fi
+	fi
+
+		if test "$fla_enable_hip" = "yes" ; then
+		if test "$fla_enable_supermatrix" = "no" ; then
+			as_fn_error 1 "Configuring libflame to enable HIP support without also enabling SuperMatrix is not allowed. HIP utilization requires that SuperMatrix be enabled. Please adjust your configure options accordingly and then re-run configure." "$LINENO" 5
+		fi
+	fi
+
+
+
+
+
+
+
+		if test "$fla_enable_gpu" = "yes" ; then
+		if test "$fla_enable_hip" = "yes" ; then
+			as_fn_error 1 "Configuring libflame to enable GPU and HIP support is not allowed. Please adjust your configure options accordingly and then re-run configure." "$LINENO" 5
 		fi
 	fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -466,9 +466,15 @@ FLA_CHECK_ENABLE_SUPERMATRIX
 dnl Observe the GPU extension switch.
 FLA_CHECK_ENABLE_GPU
 
+dnl Observe the HIP extension switch.
+FLA_CHECK_ENABLE_HIP
+
 dnl Make sure the user did not request a weird combination of parallelization
 dnl options.
 FLA_REQUIRE_SUPERMATRIX_ENABLED
+
+dnl Make sure the user did not request both GPU and HIP options.
+FLA_REQUIRE_NOT_HIP_AND_GPU_ENABLED
 
 dnl Observe the vector intrinsics switch and type.
 FLA_CHECK_ENABLE_VECTOR_INTRINSICS

--- a/docs/libflame/23-setup-linux.tex
+++ b/docs/libflame/23-setup-linux.tex
@@ -531,6 +531,14 @@ If enabled, SuperMatrix must also be enabled via {\tt --enable-supermatrix}.
 Note that this option is experimental.
 {\em Disabled by default.}
 }
+{\tt --enable-hip} \\
+\configpar{
+Enable code that takes advantage of AMD accelerators/GPUs through HIP when
+performing certain computations.
+If enabled, SuperMatrix must also be enabled via {\tt --enable-supermatrix}.
+Note that this option is experimental.
+{\em Disabled by default.}
+}
 \noindent
 {\tt --enable-vector-intrinsics={\em type}} \\
 \configpar{

--- a/src/base/flamec/include/FLA_blas1_prototypes.h
+++ b/src/base/flamec/include/FLA_blas1_prototypes.h
@@ -8,6 +8,10 @@
 
 */
 
+#ifdef FLA_ENABLE_HIP
+#include <rocblas.h>
+#endif
+
 // --- top-level wrapper prototypes --------------------------------------------
 
 FLA_Error FLA_Asum( FLA_Obj x, FLA_Obj asum_x );
@@ -99,6 +103,13 @@ FLA_Error FLA_Copy_external_gpu( FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu 
 FLA_Error FLA_Scal_external_gpu( FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 FLA_Error FLA_Scalr_external_gpu( FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 
+
+// --- hip wrapper prototypes --------------------------------------------------
+
+FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
+FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
+FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
+FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_blas1_prototypes.h
+++ b/src/base/flamec/include/FLA_blas1_prototypes.h
@@ -105,11 +105,12 @@ FLA_Error FLA_Scalr_external_gpu( FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void*
 
 
 // --- hip wrapper prototypes --------------------------------------------------
-
+#ifdef FLA_ENABLE_HIP
 FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
+#endif
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_blas2_prototypes.h
+++ b/src/base/flamec/include/FLA_blas2_prototypes.h
@@ -78,9 +78,10 @@ FLA_Error FLA_Trsv_external_gpu( FLA_Uplo uplo, FLA_Trans transa, FLA_Diag diag,
 
 
 // --- hip wrapper prototypes --------------------------------------------------
-
+#ifdef FLA_ENABLE_HIP
 FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu, FLA_Obj beta, FLA_Obj y, void* y_gpu );
 FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Diag diag, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu );
+#endif
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_blas2_prototypes.h
+++ b/src/base/flamec/include/FLA_blas2_prototypes.h
@@ -8,6 +8,10 @@
 
 */
 
+#ifdef FLA_ENABLE_HIP
+#include <rocblas.h>
+#endif
+
 // --- top-level wrapper prototypes --------------------------------------------
 
 FLA_Error FLA_Gemv( FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, FLA_Obj x, FLA_Obj beta, FLA_Obj y );
@@ -72,6 +76,11 @@ FLA_Error FLA_Trsvsx_external( FLA_Uplo uplo, FLA_Trans transa, FLA_Diag diag, F
 FLA_Error FLA_Gemv_external_gpu( FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu, FLA_Obj beta, FLA_Obj y, void* y_gpu );
 FLA_Error FLA_Trsv_external_gpu( FLA_Uplo uplo, FLA_Trans transa, FLA_Diag diag, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu );
 
+
+// --- hip wrapper prototypes --------------------------------------------------
+
+FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu, FLA_Obj beta, FLA_Obj y, void* y_gpu );
+FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Diag diag, FLA_Obj A, void* A_gpu, FLA_Obj x, void* x_gpu );
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_blas3_prototypes.h
+++ b/src/base/flamec/include/FLA_blas3_prototypes.h
@@ -155,7 +155,7 @@ FLA_Error FLA_Trsm_external_gpu( FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, 
 
 
 // --- hip wrapper prototypes --------------------------------------------------
-
+#ifdef FLA_ENABLE_HIP
 FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
 FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
 FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
@@ -165,6 +165,7 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
 FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
+#endif
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_blas3_prototypes.h
+++ b/src/base/flamec/include/FLA_blas3_prototypes.h
@@ -8,6 +8,10 @@
 
 */
 
+#ifdef FLA_ENABLE_HIP
+#include <rocblas.h>
+#endif
+
 // --- top-level wrapper prototypes --------------------------------------------
 
 FLA_Error FLA_Gemm( FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, FLA_Obj B, FLA_Obj beta, FLA_Obj C );
@@ -149,6 +153,18 @@ FLA_Error FLA_Syr2k_external_gpu( FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha,
 FLA_Error FLA_Trmm_external_gpu( FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Trsm_external_gpu( FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 
+
+// --- hip wrapper prototypes --------------------------------------------------
+
+FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu, FLA_Obj beta, FLA_Obj C, void* C_gpu );
+FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
+FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 
 // --- check routine prototypes ------------------------------------------------
 

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -8,6 +8,10 @@
 
 */
 
+#ifdef FLA_ENABLE_HIP
+#include <rocblas.h>
+#endif
+
 // -----------------------------------------------------------------------------
 
 fla_blocksize_t* FLA_Blocksize_create( dim_t b_s, dim_t b_d, dim_t b_c, dim_t b_z );
@@ -341,6 +345,13 @@ void          FLA_Param_map_flame_to_netlib_storev( FLA_Store storev, void* lapa
 void          FLA_Param_map_flame_to_netlib_evd_type( FLA_Evd_type evd_type, void* lapack_evd_type );
 void          FLA_Param_map_flame_to_netlib_svd_type( FLA_Svd_type svd_type, void* lapack_svd_type );
 void          FLA_Param_map_flame_to_netlib_machval( FLA_Machval machval, void* blas_machval );
+
+#ifdef FLA_ENABLE_HIP
+rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans );
+rocblas_fill      FLA_Param_map_flame_to_rocblas_uplo( FLA_Uplo uplo );
+rocblas_side      FLA_Param_map_flame_to_rocblas_side( FLA_Side side );
+rocblas_diagonal  FLA_Param_map_flame_to_rocblas_diag( FLA_Diag diag );
+#endif
 
 void          FLA_Param_map_flame_to_blis_trans( FLA_Trans trans, trans1_t* blis_trans );
 void          FLA_Param_map_flame_to_blis_conj( FLA_Conj conj, conj1_t* blis_conj );

--- a/src/base/flamec/include/FLA_type_defs.h
+++ b/src/base/flamec/include/FLA_type_defs.h
@@ -205,6 +205,9 @@ struct FLASH_Task_s
   // GPU enabled task
   FLA_Bool      enabled_gpu;
 
+  // HIP enabled task
+  FLA_Bool      enabled_hip;
+
   // Integer arguments
   int           n_int_args;
   int*          int_arg;

--- a/src/base/flamec/main/FLA_Param.c
+++ b/src/base/flamec/main/FLA_Param.c
@@ -9,6 +9,9 @@
 */
 
 #include "FLAME.h"
+#ifdef FLA_ENABLE_HIP
+#include <rocblas.h>
+#endif
 
 // --- FLAME to BLAS/LAPACK mappings -------------------------------------------
 
@@ -44,6 +47,28 @@ void FLA_Param_map_flame_to_netlib_trans( FLA_Trans trans, void* blas_trans )
 	}
 }
 
+#ifdef FLA_ENABLE_HIP
+rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans)
+{
+	if ( trans == FLA_NO_TRANSPOSE )
+	{
+		return rocblas_operation_none;
+	} else if ( trans == FLA_TRANSPOSE )
+	{
+		return rocblas_operation_transpose;
+	}
+	else if ( trans == FLA_CONJ_TRANSPOSE )
+	{
+		return rocblas_operation_conjugate_transpose;
+	}
+	else
+	{
+		FLA_Check_error_code( FLA_INVALID_TRANS );
+		return rocblas_operation_none; // to silence warning
+	}
+}
+#endif
+
 void FLA_Param_map_flame_to_netlib_uplo( FLA_Uplo uplo, void* blas_uplo )
 {
 	if ( uplo == FLA_LOWER_TRIANGULAR )
@@ -67,6 +92,25 @@ void FLA_Param_map_flame_to_netlib_uplo( FLA_Uplo uplo, void* blas_uplo )
 		FLA_Check_error_code( FLA_INVALID_UPLO );
 	}
 }
+
+#ifdef FLA_ENABLE_HIP
+rocblas_fill FLA_Param_map_flame_to_rocblas_uplo( FLA_Uplo uplo )
+{
+	if ( uplo == FLA_LOWER_TRIANGULAR )
+	{
+		return rocblas_fill_lower;
+	}
+	else if ( uplo == FLA_UPPER_TRIANGULAR )
+	{
+		return rocblas_fill_upper;
+	}
+	else
+	{
+		FLA_Check_error_code( FLA_INVALID_UPLO );
+		return rocblas_fill_lower; // to silence warning
+	}
+}
+#endif
 
 void FLA_Param_map_flame_to_netlib_side( FLA_Side side, void* blas_side )
 {
@@ -92,6 +136,25 @@ void FLA_Param_map_flame_to_netlib_side( FLA_Side side, void* blas_side )
 	}
 }
 
+#ifdef FLA_ENABLE_HIP
+rocblas_side FLA_Param_map_flame_to_rocblas_side( FLA_Side side )
+{
+	if ( side == FLA_LEFT )
+	{
+		return rocblas_side_left;
+	}
+	else if ( side == FLA_RIGHT )
+	{
+		return rocblas_side_right;
+	}
+	else
+	{
+		FLA_Check_error_code( FLA_INVALID_SIDE );
+		return rocblas_side_left; // to silence warning
+	}
+}
+#endif
+
 void FLA_Param_map_flame_to_netlib_diag( FLA_Diag diag, void* blas_diag )
 {
 	if ( diag == FLA_NONUNIT_DIAG )
@@ -115,6 +178,25 @@ void FLA_Param_map_flame_to_netlib_diag( FLA_Diag diag, void* blas_diag )
 		FLA_Check_error_code( FLA_INVALID_DIAG );
 	}
 }
+
+#ifdef FLA_ENABLE_HIP
+rocblas_diagonal FLA_Param_map_flame_to_rocblas_diag( FLA_Diag diag )
+{
+	if ( diag == FLA_NONUNIT_DIAG )
+	{
+		return rocblas_diagonal_non_unit;
+	}
+	else if ( diag == FLA_UNIT_DIAG )
+	{
+		return rocblas_diagonal_unit;
+	}
+	else
+	{
+		FLA_Check_error_code( FLA_INVALID_DIAG );
+		return rocblas_diagonal_non_unit; // to silence warning
+	}
+}
+#endif
 
 void FLA_Param_map_flame_to_netlib_direct( FLA_Direct direct, void* lapack_direct )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
@@ -1,0 +1,112 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  int          m_B, n_B;
+  int          ldim_A, inc_A;
+  int          ldim_B, inc_B;
+  int          i;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Axpy_check( alpha, A, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  ldim_A   = FLA_Obj_length( A );
+  inc_A    = 1;
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  ldim_B   = FLA_Obj_length( B );
+  inc_B    = 1;
+
+  switch ( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
+    float* buff_A_hip = ( float* ) A_hip;
+    float* buff_B_hip = ( float* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_saxpy( handle,
+                     m_B,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
+    double* buff_A_hip = ( double* ) A_hip;
+    double* buff_B_hip = ( double* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_daxpy( handle,
+                     m_B,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+    rocblas_float_complex* buff_B_hip = ( rocblas_float_complex* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_caxpy( handle,
+                     m_B,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+    rocblas_double_complex* buff_B_hip = ( rocblas_double_complex* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_zaxpy( handle,
+                     m_B,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
@@ -1,0 +1,107 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  int          m_B, n_B;
+  int          ldim_A, inc_A;
+  int          ldim_B, inc_B;
+  int          i;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Copy_check( A, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  // It is important that we get the datatype of B and not A, since A could
+  // be an FLA_CONSTANT.
+  datatype = FLA_Obj_datatype( B );
+
+  ldim_A   = FLA_Obj_length( A );
+  inc_A    = 1;
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  ldim_B   = FLA_Obj_length( B );
+  inc_B    = 1;
+
+  switch ( datatype ){
+
+  case FLA_INT:
+  case FLA_FLOAT:
+  {
+    float* buff_A_hip = ( float* ) A_hip;
+    float* buff_B_hip = ( float* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_scopy( handle,
+                     m_B,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_A_hip = ( double* ) A_hip;
+    double* buff_B_hip = ( double* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_dcopy( handle,
+                     m_B,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+    rocblas_float_complex* buff_B_hip = ( rocblas_float_complex* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_ccopy( handle,
+                     m_B,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+    rocblas_double_complex* buff_B_hip = ( rocblas_double_complex* ) B_hip;
+
+    for ( i = 0; i < n_B; i++ )
+      rocblas_zcopy( handle,
+                     m_B,
+                     buff_A_hip + i * ldim_A, inc_A,
+                     buff_B_hip + i * ldim_B, inc_B );
+
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
@@ -1,0 +1,105 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A;
+  int          ldim_A, inc_A;
+  int          i;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Scal_check( alpha, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  if ( FLA_Obj_equals( alpha, FLA_ONE ) )
+  {
+    return FLA_SUCCESS;
+  }
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+  inc_A    = 1;
+
+  switch ( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
+    float* buff_A_hip = ( float* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_sscal( handle,
+                     m_A,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
+    double* buff_A_hip = ( double* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_dscal( handle,
+                     m_A,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_cscal( handle,
+                     m_A,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_zscal( handle,
+                     m_A,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
@@ -1,0 +1,173 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A;
+  int          ldim_A, inc_A;
+  int          i;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Scalr_check( uplo, alpha, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  if ( FLA_Obj_equals( alpha, FLA_ONE ) )
+  {
+    return FLA_SUCCESS;
+  }
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+  inc_A    = 1;
+
+  if ( uplo == FLA_LOWER_TRIANGULAR ){
+
+  switch ( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
+    float* buff_A_hip = ( float* ) A_hip;
+
+    for ( i = 0; i < min( n_A, m_A ); i++ )
+      rocblas_sscal( handle,
+                     m_A - i,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A + i, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
+    double* buff_A_hip = ( double* ) A_hip;
+
+    for ( i = 0; i < min( n_A, m_A ); i++ )
+      rocblas_dscal( handle,
+                     m_A - i,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A + i, inc_A );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+
+    for ( i = 0; i < min( n_A, m_A ); i++ )
+      rocblas_cscal( handle,
+                     m_A - i,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A + i, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+
+    for ( i = 0; i < min( n_A, m_A ); i++ )
+      rocblas_zscal( handle,
+                     m_A - i,
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A + i, inc_A );
+
+    break;
+  }
+
+  }
+
+  }
+
+  else if ( uplo == FLA_UPPER_TRIANGULAR ){
+
+  switch ( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
+    float* buff_A_hip = ( float* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_sscal( handle,
+                     min( i + 1, m_A ),
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
+    double* buff_A_hip = ( double* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_dscal( handle,
+                     min( i + 1, m_A ),
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_cscal( handle,
+                     min( i + 1, m_A ),
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+
+    for ( i = 0; i < n_A; i++ )
+      rocblas_zscal( handle,
+                     min( i + 1, m_A ),
+                     buff_alpha,
+                     buff_A_hip + i * ldim_A, inc_A );
+
+    break;
+  }
+
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -1,0 +1,122 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip, FLA_Obj beta, FLA_Obj y, void* y_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A;
+  int          ldim_A;
+  int          inc_x;
+  int          inc_y;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Gemv_check( transa, alpha, A, x, beta, y );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  inc_x    = 1;
+  inc_y    = 1;
+
+  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa );
+
+
+  switch( datatype ){
+  
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_sgemv( handle,
+		   blas_transa,
+                   m_A,
+                   n_A, 
+                   buff_alpha,                   
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) x_hip, inc_x,
+                   buff_beta,
+                   ( float * ) y_hip, inc_y );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dgemv( handle,
+		   blas_transa,
+                   m_A,
+                   n_A, 
+                   buff_alpha,                   
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) x_hip, inc_x,
+                   buff_beta,
+                   ( double * ) y_hip, inc_y );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_cgemv( handle,
+		   blas_transa,
+                   m_A,
+                   n_A, 
+                   buff_alpha,                   
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) x_hip, inc_x,
+                   buff_beta,
+                   ( rocblas_float_complex * ) y_hip, inc_y );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zgemv( handle,
+		   blas_transa,
+                   m_A,
+                   n_A, 
+                   buff_alpha,                   
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) x_hip, inc_x,
+                   buff_beta,
+                   ( rocblas_double_complex * ) y_hip, inc_y );
+
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -1,0 +1,97 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip ) 
+{
+  FLA_Datatype datatype;
+  int          m_A;
+  int          ldim_A;
+  int          inc_x;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Trsv_check( uplo, trans, diag, A, x );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  inc_x    = 1;
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    rocblas_strsv( handle, blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_A,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) x_hip, inc_x );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    rocblas_dtrsv( handle, blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_A,
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) x_hip, inc_x );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_ctrsv( handle, blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_A,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) x_hip, inc_x );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_ztrsv( handle, blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_A,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) x_hip, inc_x );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -1,0 +1,147 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          k_AB;
+  int          m_A, n_A;
+  int          m_C, n_C;
+  int          ldim_A;
+  int          ldim_B;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Gemm_check( transa, transb, alpha, A, B, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  if ( FLA_Obj_has_zero_dim( A ) || FLA_Obj_has_zero_dim( B ) )
+  {
+    FLA_Scal_external_hip( handle, beta, C, C_hip );
+    return FLA_SUCCESS;
+  }
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  ldim_B   = FLA_Obj_length( B );
+
+  m_C      = FLA_Obj_length( C );
+  n_C      = FLA_Obj_width( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  if ( transa == FLA_NO_TRANSPOSE || transa == FLA_CONJ_NO_TRANSPOSE )
+    k_AB = n_A;
+  else
+    k_AB = m_A;
+
+  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa );
+  rocblas_operation blas_transb = FLA_Param_map_flame_to_rocblas_trans( transb );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_sgemm( handle,
+                   blas_transa,
+                   blas_transb,
+                   m_C,
+                   n_C,
+                   k_AB,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dgemm( handle,
+                   blas_transa,
+                   blas_transb,
+                   m_C,
+                   n_C,
+                   k_AB,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( double * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_cgemm( handle,
+                   blas_transa,
+                   blas_transb,
+                   m_C,
+                   n_C,
+                   k_AB,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_float_complex * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zgemm( handle,
+                   blas_transa,
+                   blas_transb,
+                   m_C,
+                   n_C,
+                   k_AB,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_double_complex * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
@@ -1,0 +1,128 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          m_C, n_C;
+  int          ldim_A;
+  int          ldim_B;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Hemm_check( side, uplo, alpha, A, B, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  ldim_A   = FLA_Obj_length( A );
+
+  ldim_B   = FLA_Obj_length( B );
+
+  m_C      = FLA_Obj_length( C );
+  n_C      = FLA_Obj_width( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_ssymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dsymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( double * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_chemm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_float_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zhemm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_double_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  }
+ 
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -1,0 +1,136 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          k_AB;
+  int          m_A, n_A;
+  int          m_C;
+  int          ldim_A;
+  int          ldim_B;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Her2k_check( uplo, trans, alpha, A, B, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  ldim_B   = FLA_Obj_length( B );
+
+  m_C      = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  if ( trans == FLA_NO_TRANSPOSE )
+    k_AB = n_A;
+  else
+    k_AB = m_A;
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+    
+    rocblas_ssyr2k( handle,
+		    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( float * ) A_hip, ldim_A,
+                    ( float * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+    
+    rocblas_dsyr2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( double * ) A_hip, ldim_A,
+                    ( double * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( double * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    float *buff_beta = ( float * ) FLA_FLOAT_PTR( beta );
+    
+    rocblas_cher2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( rocblas_float_complex * ) A_hip, ldim_A,
+                    ( rocblas_float_complex * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( rocblas_float_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    double *buff_beta = ( double * ) FLA_DOUBLE_PTR( beta );
+    
+    rocblas_zher2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( rocblas_double_complex * ) A_hip, ldim_A,
+                    ( rocblas_double_complex * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( rocblas_double_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  }
+ 
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -1,0 +1,129 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          k_A;
+  int          m_A, n_A;
+  int          m_C;
+  int          ldim_A;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Herk_check( uplo, trans, alpha, A, beta, C );
+  
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  m_C      = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  if ( trans == FLA_NO_TRANSPOSE )
+    k_A = n_A;
+  else
+    k_A = m_A;
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_ssyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dsyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( double * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_cherk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( rocblas_float_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_zherk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( rocblas_double_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  }
+ 
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
@@ -1,0 +1,128 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          m_C, n_C;
+  int          ldim_A;
+  int          ldim_B;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Symm_check( side, uplo, alpha, A, B, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  ldim_A   = FLA_Obj_length( A );
+
+  ldim_B   = FLA_Obj_length( B );
+
+  m_C      = FLA_Obj_length( C );
+  n_C      = FLA_Obj_width( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_ssymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dsymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( double * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_csymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_float_complex * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zsymm( handle,
+                   blas_side,
+                   blas_uplo,
+                   m_C,
+                   n_C,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   buff_beta,
+                   ( rocblas_double_complex * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -1,0 +1,136 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          k_AB;
+  int          m_A, n_A;
+  int          m_C;
+  int          ldim_A;
+  int          ldim_B;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Syr2k_check( uplo, trans, alpha, A, B, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  ldim_B   = FLA_Obj_length( B );
+
+  m_C      = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  if ( trans == FLA_NO_TRANSPOSE )
+    k_AB = n_A;
+  else
+    k_AB = m_A;
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_ssyr2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( float * ) A_hip, ldim_A,
+                    ( float * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dsyr2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( double * ) A_hip, ldim_A,
+                    ( double * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( double * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_csyr2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( rocblas_float_complex * ) A_hip, ldim_A,
+                    ( rocblas_float_complex * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( rocblas_float_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zsyr2k( handle,
+                    blas_uplo,
+                    blas_trans,
+                    m_C,
+                    k_AB,
+                    buff_alpha,
+                    ( rocblas_double_complex * ) A_hip, ldim_A,
+                    ( rocblas_double_complex * ) B_hip, ldim_B,
+                    buff_beta,
+                    ( rocblas_double_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -1,0 +1,129 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
+{
+  FLA_Datatype datatype;
+  int          k_A;
+  int          m_A, n_A;
+  int          m_C;
+  int          ldim_A;
+  int          ldim_C;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Syrk_check( uplo, trans, alpha, A, beta, C );
+
+  if ( FLA_Obj_has_zero_dim( C ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  m_C      = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_length( C );
+
+  if ( trans == FLA_NO_TRANSPOSE )
+    k_A = n_A;
+  else
+    k_A = m_A;
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+    float *buff_beta  = ( float * ) FLA_FLOAT_PTR( beta );
+
+    rocblas_ssyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( float * ) C_hip, ldim_C );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+    double *buff_beta  = ( double * ) FLA_DOUBLE_PTR( beta );
+
+    rocblas_dsyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( double * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+    rocblas_float_complex *buff_beta  = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( beta );
+
+    rocblas_csyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( rocblas_float_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+    rocblas_double_complex *buff_beta  = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( beta );
+
+    rocblas_zsyrk( handle,
+                   blas_uplo,
+                   blas_trans,
+                   m_C,
+                   k_A,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   buff_beta,
+                   ( rocblas_double_complex * ) C_hip, ldim_C );
+
+    break;
+  }
+
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -1,0 +1,123 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  int          m_B, n_B;
+  int          ldim_A;
+  int          ldim_B;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Trmm_check( side, uplo, trans, diag, alpha, A, B );
+
+  if ( FLA_Obj_has_zero_dim( B ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  ldim_A   = FLA_Obj_length( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  ldim_B   = FLA_Obj_length( B );
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+
+    rocblas_strmm( handle,
+                   blas_side,
+                   blas_uplo, 
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) B_hip, ldim_B );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+
+    rocblas_dtrmm( handle,
+                   blas_side,
+                   blas_uplo, 
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( double * ) A_hip, ldim_A,
+                   ( double * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+
+    rocblas_ctrmm( handle,
+                   blas_side,
+                   blas_uplo, 
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+
+    rocblas_ztrmm( handle,
+                   blas_side,
+                   blas_uplo, 
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -1,0 +1,123 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "rocblas.h"
+
+FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  int          m_B, n_B;
+  int          ldim_A;
+  int          ldim_B;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Trsm_check( side, uplo, trans, diag, alpha, A, B );
+
+  if ( FLA_Obj_has_zero_dim( B ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  ldim_A   = FLA_Obj_length( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  ldim_B   = FLA_Obj_length( B );
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_alpha = ( float * ) FLA_FLOAT_PTR( alpha );
+
+    rocblas_strsm( handle,
+                   blas_side,
+                   blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( float * ) A_hip, ldim_A,
+                   ( float * ) B_hip, ldim_B );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_alpha = ( double * ) FLA_DOUBLE_PTR( alpha );
+
+    rocblas_dtrsm( handle,
+                 blas_side,
+                 blas_uplo,
+                 blas_trans,
+                 blas_diag,
+                 m_B,
+                 n_B,
+                 buff_alpha,
+                 ( double * ) A_hip, ldim_A,
+                 ( double * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_alpha = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( alpha );
+
+    rocblas_ctrsm( handle,
+                   blas_side,
+                   blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_alpha = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( alpha );
+
+    rocblas_ztrsm( handle,
+                   blas_side,
+                   blas_uplo,
+                   blas_trans,
+                   blas_diag,
+                   m_B,
+                   n_B,
+                   buff_alpha,
+                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) B_hip, ldim_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ INC_PATH        := $(INCLUDE_DIR)/$(HOST)/
 LIBBLAS_PATH   := $(INSTALL_LIBDIR)
 #LIBBLAS        := $(LIBBLAS_PATH)/libblas.a
 LIBBLAS        := $(LIBBLAS_PATH)/libopenblas.a
-#LIBBLAS        := ${HOME}/blis/lib/libblis.a
+#LIBBLAS        := $(HOME)/blis/lib/libblis.a
 
 # LAPACK implementation path. These values only matter if libflame was
 # configured with the external-lapack-interfaces option enabled. Modify

--- a/test/Makefile
+++ b/test/Makefile
@@ -52,8 +52,8 @@ INC_PATH        := $(INCLUDE_DIR)/$(HOST)/
 # the libflame test suite. Modify these definitions if needed.
 LIBBLAS_PATH   := $(INSTALL_LIBDIR)
 #LIBBLAS        := $(LIBBLAS_PATH)/libblas.a
-LIBBLAS        := $(LIBBLAS_PATH)/libopenblas.a
-#LIBBLAS        := $(HOME)/blis/lib/libblis.a
+#LIBBLAS        := $(LIBBLAS_PATH)/libopenblas.a
+LIBBLAS        := /dockerx/blis/lib/zen/libblis.a
 
 # LAPACK implementation path. These values only matter if libflame was
 # configured with the external-lapack-interfaces option enabled. Modify

--- a/test/Makefile
+++ b/test/Makefile
@@ -52,8 +52,8 @@ INC_PATH        := $(INCLUDE_DIR)/$(HOST)/
 # the libflame test suite. Modify these definitions if needed.
 LIBBLAS_PATH   := $(INSTALL_LIBDIR)
 #LIBBLAS        := $(LIBBLAS_PATH)/libblas.a
-#LIBBLAS        := $(LIBBLAS_PATH)/libopenblas.a
-LIBBLAS        := /dockerx/blis/lib/zen/libblis.a
+LIBBLAS        := $(LIBBLAS_PATH)/libopenblas.a
+#LIBBLAS        := ${HOME}/blis/lib/libblis.a
 
 # LAPACK implementation path. These values only matter if libflame was
 # configured with the external-lapack-interfaces option enabled. Modify


### PR DESCRIPTION
Add --enable-hip configure option and checks.
Bootstrap configure file.
Add FLA_ENABLE_HIP preprocessor directive.
Add helper functions to map flame internal enums to rocBLAS.
Add BLAS1/BLAS2/BLAS3 HIP prototypes.
Add BLAS1/BLAS2/BLAS3 HIP wrapper implementations modified from the existing CUDA ones.
Add basic documentation.

There is no queue implementation yet.