### PR TITLE
Add HIP support to libflame (part 2)

### DIFF
--- a/docs/libflame/40-user-api.tex
+++ b/docs/libflame/40-user-api.tex
@@ -5873,9 +5873,97 @@ An unsigned integer representing the number of blocks maintained by each GPU.
 }
 \end{flaspec}
 
+% --- FLASH_Queue_enable_hip() -------------------------------------------------
 
+\begin{flaspec}
+\begin{verbatim}
+FLA_Error FLASH_Queue_enable_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueueenablegpuns}
+\purpose{
+Enable run-time support for HIP accelerator execution.
+When enabled, SuperMatrix tasks that are HIP-supported are executed on HIP
+devices, while all other tasks are run on the CPU.
+}
+\rvalue{
+\flasuccess if SuperMatrix is enabled and a parallel region has not yet
+begun;
+\flafailure otherwise.
+}
+\end{flaspec}
 
+% --- FLASH_Queue_disable_hip() ------------------------------------------------
 
+\begin{flaspec}
+\begin{verbatim}
+FLA_Error FLASH_Queue_disable_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueuedisablegpuns}
+\purpose{
+Disable run-time support for HIP accelerator execution.
+When disabled, all SuperMatrix tasks are run on the CPU.
+}
+\rvalue{
+\flasuccess if a parallel region has not yet begun;
+\flafailure otherwise.
+}
+\end{flaspec}
+
+% --- FLASH_Queue_get_enabled_hip() --------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+FLA_Bool FLASH_Queue_get_enabled_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueuegetenabledgpuns}
+\purpose{
+Query whether HIP accelerator execution is currently enabled.
+}
+\notes{
+If SuperMatrix is currently disabled, the function returns \false regardless
+of whether HIP accelerator execution was previously enabled.
+}
+\rvalue{
+\true if SuperMatrix and HIP execution are both enabled;
+\false if SuperMatrix is disabled, or if SuperMatrix is enabled but HIP
+execution is disabled.
+}
+\end{flaspec}
+
+% --- FLASH_Queue_set_hip_num_blocks() -----------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLASH_Queue_set_hip_num_blocks( dim_t n_blocks );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueuesetgpunumblocksns}
+\purpose{
+Set the number of storage blocks maintained by each HIP device.
+}
+\notes{
+If the user encounters a run-time error reporting that an attempt to allocate
+memory on a HIP device failed, it may be necessary to set \nblocks
+to a lower value.
+}
+\begin{params}
+\parameter{\dimt}{n\_blocks}{An unsigned integer representing the number of blocks maintained by each HIP device.}
+\end{params}
+\end{flaspec}
+
+% --- FLASH_Queue_get_hip_num_blocks() -----------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+dim_t FLASH_Queue_get_hip_num_blocks( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueuegetgpunumblocksns}
+\purpose{
+Query the number of storage blocks maintained by each HIP device.
+}
+\rvalue{
+An unsigned integer representing the number of blocks maintained by each HIP device.
+}
+\end{flaspec}
 
 
 

--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -1,0 +1,42 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#ifndef FLASH_QUEUE_HIP_H
+#define FLASH_QUEUE_HIP_H
+
+#ifdef FLA_ENABLE_HIP
+
+
+void           FLASH_Queue_init_hip( void );
+void           FLASH_Queue_finalize_hip( void );
+
+FLA_Error      FLASH_Queue_enable_hip( void );
+FLA_Error      FLASH_Queue_disable_hip( void );
+FLA_Bool       FLASH_Queue_get_enabled_hip( void );
+
+
+// --- helper functions -------------------------------------------------------
+
+void           FLASH_Queue_set_hip_num_blocks( dim_t n_blocks );
+dim_t          FLASH_Queue_get_hip_num_blocks( void );
+
+FLA_Error      FLASH_Queue_bind_hip( int thread );
+FLA_Error      FLASH_Queue_alloc_hip( dim_t size, FLA_Datatype datatype, void** buffer_hip );
+FLA_Error      FLASH_Queue_free_hip( void* buffer_hip );
+FLA_Error      FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_read_hip( FLA_Obj obj, void* buffer_hip );
+
+void           FLASH_Queue_exec_task_hip( FLASH_Task* t, void** input_arg, void** output_arg );
+
+
+#endif
+
+#endif // FLASH_QUEUE_HIP_H

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -1,0 +1,513 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime.h"
+#include "rocblas.h"
+
+
+static FLA_Bool flash_queue_enabled_hip  = FALSE;
+static dim_t    flash_queue_hip_n_blocks = 128;
+static rocblas_handle handle;
+
+void FLASH_Queue_init_hip( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_init_hip
+
+----------------------------------------------------------------------------*/
+{
+   // XXX TODO it would be preferable to have one handle per device with a
+   // dedicated stream
+   rocblas_create_handle( &handle );
+
+   return;
+}
+
+
+void FLASH_Queue_finalize_hip( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_finalize_hip
+
+----------------------------------------------------------------------------*/
+{
+   rocblas_destroy_handle( handle );
+
+   return;
+}
+
+
+FLA_Error FLASH_Queue_enable_hip( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_enable_hip
+
+----------------------------------------------------------------------------*/
+{
+   if ( FLASH_Queue_stack_depth() == 0 && FLASH_Queue_get_enabled() )
+   {
+      // Enable if not begin parallel region yet and SuperMatrix is enabled.
+      flash_queue_enabled_hip = TRUE;
+      return FLA_SUCCESS;
+   }
+   else
+   {
+      // Cannot change status during parallel region.
+      return FLA_FAILURE;
+   }
+}
+
+
+FLA_Error FLASH_Queue_disable_hip( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_disable_hip
+
+----------------------------------------------------------------------------*/
+{
+   if ( FLASH_Queue_stack_depth() == 0 )
+   {
+      // Disable if not begin parallel region yet.
+      flash_queue_enabled_hip = FALSE;
+      return FLA_SUCCESS;
+   }
+   else
+   {
+      // Cannot change status during parallel region.
+      return FLA_FAILURE;
+   }
+}
+
+
+FLA_Bool FLASH_Queue_get_enabled_hip( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_get_enabled_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Return if SuperMatrix is enabled, but always false if not.
+   if ( FLASH_Queue_get_enabled() )
+      return flash_queue_enabled_hip;
+   else
+      return FALSE;
+}
+
+
+void FLASH_Queue_set_hip_num_blocks( dim_t n_blocks )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_set_hip_num_blocks
+
+----------------------------------------------------------------------------*/
+{
+   flash_queue_hip_n_blocks = n_blocks;
+
+   return;
+}
+
+
+dim_t FLASH_Queue_get_hip_num_blocks( void )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_get_hip_num_blocks
+
+----------------------------------------------------------------------------*/
+{
+   return flash_queue_hip_n_blocks;
+}
+
+
+// --- helper functions --- ===================================================
+
+
+FLA_Error FLASH_Queue_bind_hip( int thread )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_bind_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Bind a HIP device to this thread.
+   // XXX TODO it is unclear if this works as intended for a mGPU case
+   // (see note about rocblas_handle && stream per device above)
+   hipSetDevice( thread );
+
+   return FLA_SUCCESS;
+}
+
+
+FLA_Error FLASH_Queue_alloc_hip( dim_t size,
+                                 FLA_Datatype datatype,
+                                 void** buffer_hip )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_alloc_hip
+
+----------------------------------------------------------------------------*/
+{
+   hipError_t status;
+
+   // Allocate memory for a block on HIP.
+   status = hipMalloc( buffer_hip,
+		       size * FLA_Obj_datatype_size( datatype ) );
+
+   // Check to see if the allocation was successful.
+   if ( status != hipSuccess )
+      FLA_Check_error_code( FLA_MALLOC_GPU_RETURNED_NULL_POINTER );
+
+   return FLA_SUCCESS;
+}
+
+
+FLA_Error FLASH_Queue_free_hip( void* buffer_hip )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_free_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Free memory for a block on HIP.
+   hipFree( buffer_hip );
+
+   return FLA_SUCCESS;
+}
+
+
+FLA_Error FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_write_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Write the contents of a block in main memory to HIP.
+   rocblas_set_matrix( FLA_Obj_length( obj ),
+                       FLA_Obj_width( obj ),
+                       FLA_Obj_datatype_size( FLA_Obj_datatype( obj ) ),
+                       FLA_Obj_buffer_at_view( obj ), 
+                       FLA_Obj_col_stride( obj ),
+                       buffer_hip,
+                       FLA_Obj_length( obj ) );
+
+   return FLA_SUCCESS;
+}
+
+
+FLA_Error FLASH_Queue_read_hip( FLA_Obj obj, void* buffer_hip )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_read_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Read the memory of a block on HIP to main memory.
+   rocblas_get_matrix( FLA_Obj_length( obj ),
+                       FLA_Obj_width( obj ),
+                       FLA_Obj_datatype_size( FLA_Obj_datatype( obj ) ),
+                       buffer_hip,
+                       FLA_Obj_length( obj ),
+                       FLA_Obj_buffer_at_view( obj ),
+                       FLA_Obj_col_stride( obj ) );
+
+   return FLA_SUCCESS;
+}
+
+
+void FLASH_Queue_exec_task_hip( FLASH_Task* t, 
+                                void** input_arg, 
+                                void** output_arg )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_exec_task_hip
+
+----------------------------------------------------------------------------*/
+{
+   // Define local function pointer types.
+
+   // Level-3 BLAS
+   typedef FLA_Error(*flash_gemm_hip_p)(rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_hemm_hip_p)(rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_herk_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_her2k_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_symm_hip_p)(rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_syrk_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_syr2k_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_trmm_hip_p)(rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj C, void* C_hip);
+   typedef FLA_Error(*flash_trsm_hip_p)(rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj C, void* C_hip);
+
+   // Level-2 BLAS
+   typedef FLA_Error(*flash_gemv_hip_p)(rocblas_handle handle, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip, FLA_Obj beta, FLA_Obj y, void* y_hip);
+   typedef FLA_Error(*flash_trsv_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip);
+
+   // Level-1 BLAS
+   typedef FLA_Error(*flash_axpy_hip_p)(rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip);
+   typedef FLA_Error(*flash_copy_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip);
+   typedef FLA_Error(*flash_scal_hip_p)(rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip);
+   typedef FLA_Error(*flash_scalr_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip);
+
+   // Only execute task if it is not NULL.
+   if ( t == NULL )
+      return;
+
+   // Now "switch" between the various possible task functions.
+
+   // FLA_Gemm
+   if ( t->func == (void *) FLA_Gemm_task )
+   {
+      flash_gemm_hip_p func;
+      func = (flash_gemm_hip_p) FLA_Gemm_external_hip;
+      
+      func(                 handle,
+            ( FLA_Trans   ) t->int_arg[0],
+            ( FLA_Trans   ) t->int_arg[1],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->input_arg[1],
+                            input_arg[1],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Hemm
+   else if ( t->func == (void *) FLA_Hemm_task )
+   {
+      flash_hemm_hip_p func;
+      func = (flash_hemm_hip_p) FLA_Hemm_external_hip;
+      
+      func(                 handle,
+            ( FLA_Side    ) t->int_arg[0],
+            ( FLA_Uplo    ) t->int_arg[1],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->input_arg[1],
+                            input_arg[1],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Herk
+   else if ( t->func == (void *) FLA_Herk_task )
+   {
+      flash_herk_hip_p func;
+      func = (flash_herk_hip_p) FLA_Herk_external_hip;
+      
+      func(                 handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+            ( FLA_Trans   ) t->int_arg[1],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Her2k
+   else if ( t->func == (void *) FLA_Her2k_task )
+   {
+      flash_her2k_hip_p func;
+      func = (flash_her2k_hip_p) FLA_Her2k_external_hip;
+      
+      func(                  handle,
+            ( FLA_Uplo     ) t->int_arg[0],
+            ( FLA_Trans    ) t->int_arg[1],
+                             t->fla_arg[0],
+                             t->input_arg[0],
+                             input_arg[0],
+                             t->input_arg[1],
+                             input_arg[1],
+                             t->fla_arg[1],
+                             t->output_arg[0],
+                             output_arg[0] );
+   }
+   // FLA_Symm
+   else if ( t->func == (void *) FLA_Symm_task )
+   {
+      flash_symm_hip_p func;
+      func = (flash_symm_hip_p) FLA_Symm_external_hip;
+      
+      func(                 handle,
+            ( FLA_Side    ) t->int_arg[0],
+            ( FLA_Uplo    ) t->int_arg[1],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->input_arg[1],
+                            input_arg[1],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Syrk
+   else if ( t->func == (void *) FLA_Syrk_task )
+   {
+      flash_syrk_hip_p func;
+      func = (flash_syrk_hip_p) FLA_Syrk_external_hip;
+      
+      func(                 handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+            ( FLA_Trans   ) t->int_arg[1],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Syr2k
+   else if ( t->func == (void *) FLA_Syr2k_task )
+   {
+      flash_syr2k_hip_p func;
+      func = (flash_syr2k_hip_p) FLA_Syr2k_external_hip;
+      
+      func(                  handle,
+            ( FLA_Uplo     ) t->int_arg[0],
+            ( FLA_Trans    ) t->int_arg[1],
+                             t->fla_arg[0],
+                             t->input_arg[0],
+                             input_arg[0],
+                             t->input_arg[1],
+                             input_arg[1],
+                             t->fla_arg[1],
+                             t->output_arg[0],
+                             output_arg[0] );
+   }
+   // FLA_Trmm
+   else if ( t->func == (void *) FLA_Trmm_task )
+   {
+      flash_trmm_hip_p func;
+      func = (flash_trmm_hip_p) FLA_Trmm_external_hip;
+      
+      func(                 handle,
+            ( FLA_Side    ) t->int_arg[0],
+            ( FLA_Uplo    ) t->int_arg[1],
+            ( FLA_Trans   ) t->int_arg[2],
+            ( FLA_Diag    ) t->int_arg[3],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Trsm
+   else if ( t->func == (void *) FLA_Trsm_task )
+   {
+      flash_trsm_hip_p func;
+      func = (flash_trsm_hip_p) FLA_Trsm_external_hip;
+      
+      func(                 handle,
+            ( FLA_Side    ) t->int_arg[0],
+            ( FLA_Uplo    ) t->int_arg[1],
+            ( FLA_Trans   ) t->int_arg[2],
+            ( FLA_Diag    ) t->int_arg[3],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Gemv
+   else if ( t->func == (void *) FLA_Gemv_task )
+   {
+      flash_gemv_hip_p func;
+      func = (flash_gemv_hip_p) FLA_Gemv_external_hip;
+      
+      func(                 handle,
+            ( FLA_Trans   ) t->int_arg[0],
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->input_arg[1],
+                            input_arg[1],
+                            t->fla_arg[1],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Trsv
+   else if ( t->func == (void *) FLA_Trsv_task )
+   {
+      flash_trsv_hip_p func;
+      func = (flash_trsv_hip_p) FLA_Trsv_external_hip;
+      
+      func(                 handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+            ( FLA_Trans   ) t->int_arg[1],
+            ( FLA_Diag    ) t->int_arg[2],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Axpy
+   else if ( t->func == (void *) FLA_Axpy_task )
+   {
+      flash_axpy_hip_p func;
+      func = (flash_axpy_hip_p) FLA_Axpy_external_hip;
+         
+      func(                 handle,
+                            t->fla_arg[0],
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Copy
+   else if ( t->func == (void *) FLA_Copy_task )
+   {
+      flash_copy_hip_p func;
+      func = (flash_copy_hip_p) FLA_Copy_external_hip;
+         
+      func(                 handle,
+                            t->input_arg[0],
+                            input_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Scal
+   else if ( t->func == (void *) FLA_Scal_task )
+   {
+      flash_scal_hip_p func;
+      func = (flash_scal_hip_p) FLA_Scal_external_hip;
+
+      func(                 handle,
+                            t->fla_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   // FLA_Scalr
+   else if ( t->func == (void *) FLA_Scalr_task )
+   {
+      flash_scalr_hip_p func;
+      func = (flash_scalr_hip_p) FLA_Scalr_external_hip;
+
+      func(                 handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+                            t->fla_arg[0],
+                            t->output_arg[0],
+                            output_arg[0] );
+   }
+   else
+   {
+      FLA_Check_error_code( FLA_NOT_YET_IMPLEMENTED );
+   }
+
+   return;
+}
+
+
+#endif // FLA_ENABLE_HIP

--- a/src/base/flamec/supermatrix/include/FLASH_Queue.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue.h
@@ -16,6 +16,7 @@
 #include "FLASH_Queue_macro_defs.h"
 
 #include "FLASH_Queue_gpu.h"
+#include "FLASH_Queue_hip.h"
 
 
 #endif // FLASH_QUEUE_H

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -41,6 +41,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LU   ", \
                           FALSE, \
+                          FALSE, \
                           0, 0, 0, 2, \
                           A, p )
 
@@ -48,6 +49,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Apply_pivots_macro_task, \
                           (void *) cntl, \
                           "Pivot", \
+                          FALSE, \
                           FALSE, \
                           2, 0, 1, 1, \
                           side, trans, \
@@ -58,6 +60,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LU   ", \
                           FALSE, \
+                          FALSE, \
                           0, 1, 0, 1, \
                           p, A )
 
@@ -65,6 +68,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_LU_piv_copy_task, \
                           (void *) cntl, \
                           "LU   ", \
+                          FALSE, \
                           FALSE, \
                           0, 1, 0, 2, \
                           p, A, U )
@@ -74,6 +78,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Trsm ", \
                           FALSE, \
+                          FALSE, \
                           0, 1, 1, 1, \
                           p, A, C )
 
@@ -81,6 +86,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_SA_LU_task, \
                           (void *) cntl, \
                           "SA_LU", \
+                          FALSE, \
                           FALSE, \
                           1, 2, 0, 2, \
                           nb_alg, \
@@ -91,6 +97,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "SA_FS", \
                           FALSE, \
+                          FALSE, \
                           1, 2, 1, 2, \
                           nb_alg, \
                           L, p, D, E, C )
@@ -100,6 +107,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LU   ", \
                           FALSE, \
+                          FALSE, \
                           0, 0, 0, 1, \
                           A )
 
@@ -107,6 +115,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Trinv_task, \
                           (void *) cntl, \
                           "Trinv", \
+                          FALSE, \
                           FALSE, \
                           2, 0, 0, 1, \
                           uplo, diag, \
@@ -117,6 +126,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Ttmm ", \
                           FALSE, \
+                          FALSE, \
                           1, 0, 0, 1, \
                           uplo, \
                           A )
@@ -126,6 +136,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Chol ", \
                           FALSE, \
+                          FALSE, \
                           1, 0, 0, 1, \
                           uplo, \
                           A )
@@ -134,6 +145,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Sylv_task, \
                           (void *) cntl, \
                           "Sylv ", \
+                          FALSE, \
                           FALSE, \
                           2, 2, 2, 1, \
                           transA, transB, \
@@ -145,6 +157,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Lyap ", \
                           FALSE, \
+                          FALSE, \
                           1, 2, 1, 1, \
                           trans, \
                           isgn, scale, \
@@ -155,6 +168,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "QR   ", \
                           FALSE, \
+                          FALSE, \
                           0, 0, 0, 2, \
                           A, T )
 
@@ -162,6 +176,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_QR_UT_task, \
                           (void *) cntl, \
                           "QR   ", \
+                          FALSE, \
                           FALSE, \
                           0, 1, 0, 1, \
                           T, A )
@@ -171,6 +186,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "QR   ", \
                           FALSE, \
+                          FALSE, \
                           0, 1, 0, 2, \
                           T, A, U )
 
@@ -178,6 +194,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_QR2_UT_task, \
                           (void *) cntl, \
                           "QR2  ", \
+                          FALSE, \
                           FALSE, \
                           0, 1, 0, 2, \
                           T, D, B )
@@ -187,6 +204,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LQ   ", \
                           FALSE, \
+                          FALSE, \
                           0, 0, 0, 2, \
                           A, T )
 
@@ -195,6 +213,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "CAQR2", \
                           FALSE, \
+                          FALSE, \
                           0, 1, 0, 2, \
                           T, D, B )
 
@@ -202,6 +221,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Apply_Q_UT_task, \
                           (void *) cntl, \
                           "ApQ  ", \
+                          FALSE, \
                           FALSE, \
                           4, 1, 1, 2, \
                           side, trans, direct, storev, \
@@ -212,6 +232,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "ApQ2 ", \
                           FALSE, \
+                          FALSE, \
                           4, 1, 1, 3, \
                           side, trans, direct, storev, \
                           T, D, E, C, W )
@@ -220,6 +241,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Apply_CAQ2_UT_task, \
                           (void *) cntl, \
                           "ApCQ2", \
+                          FALSE, \
                           FALSE, \
                           4, 1, 1, 3, \
                           side, trans, direct, storev, \
@@ -230,6 +252,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "UD   ", \
                           FALSE, \
+                          FALSE, \
                           0, 0, 0, 4, \
                           R, C, D, T )
 
@@ -237,6 +260,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Apply_QUD_UT_task, \
                           (void *) cntl, \
                           "ApQUD", \
+                          FALSE, \
                           FALSE, \
                           4, 0, 3, 4, \
                           side, trans, direct, storev, \
@@ -246,6 +270,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Eig_gest_task, \
                           (void *) cntl, \
                           "Eig  ", \
+                          FALSE, \
                           FALSE, \
                           2, 0, 1, 2, \
                           inv, uplo, \
@@ -258,6 +283,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Gemm ", \
                           TRUE, \
+                          TRUE, \
                           2, 2, 2, 1, \
                           transA, transB, \
                           alpha, beta, \
@@ -267,6 +293,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Hemm_task, \
                           (void *) cntl, \
                           "Hemm ", \
+                          TRUE, \
                           TRUE, \
                           2, 2, 2, 1, \
                           side, uplo, \
@@ -278,6 +305,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Herk ", \
                           TRUE, \
+                          TRUE, \
                           2, 2, 1, 1, \
                           uplo, transA, \
                           alpha, beta, \
@@ -287,6 +315,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Her2k_task, \
                           (void *) cntl, \
                           "Her2k", \
+                          TRUE, \
                           TRUE, \
                           2, 2, 2, 1, \
                           uplo, transA, \
@@ -298,6 +327,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Symm ", \
                           TRUE, \
+                          TRUE, \
                           2, 2, 2, 1, \
                           side, uplo, \
                           alpha, beta, \
@@ -307,6 +337,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Syrk_task, \
                           (void *) cntl, \
                           "Syrk ", \
+                          TRUE, \
                           TRUE, \
                           2, 2, 1, 1, \
                           uplo, transA, \
@@ -318,6 +349,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Syr2k", \
                           TRUE, \
+                          TRUE, \
                           2, 2, 2, 1, \
                           uplo, transA, \
                           alpha, beta, \
@@ -328,6 +360,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Trmm ", \
                           TRUE, \
+                          TRUE, \
                           4, 1, 1, 1, \
                           side, uplo, trans, diag, \
                           alpha, \
@@ -337,6 +370,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Trsm_task, \
                           (void *) cntl, \
                           "Trsm ", \
+                          TRUE, \
                           TRUE, \
                           4, 1, 1, 1, \
                           side, uplo, trans, diag, \
@@ -350,6 +384,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Gemv ", \
                           TRUE, \
+                          TRUE, \
                           1, 2, 2, 1, \
                           trans, \
                           alpha, beta, \
@@ -359,6 +394,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Trsv_task, \
                           (void *) cntl, \
                           "Trsv ", \
+                          TRUE, \
                           TRUE, \
                           3, 0, 1, 1, \
                           uplo, trans, diag, \
@@ -371,6 +407,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Axpy ", \
                           TRUE, \
+                          TRUE, \
                           0, 1, 1, 1, \
                           alpha, \
                           A, B )
@@ -379,6 +416,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Axpyt_task, \
                           (void *) cntl, \
                           "Axpyt", \
+                          FALSE, \
                           FALSE, \
                           1, 1, 1, 1, \
                           trans, \
@@ -390,6 +428,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Copy ", \
                           TRUE, \
+                          TRUE, \
                           0, 0, 1, 1, \
                           A, B )
 
@@ -397,6 +436,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Copyt_task, \
                           (void *) cntl, \
                           "Copyt", \
+                          FALSE, \
                           FALSE, \
                           1, 0, 1, 1, \
                           trans, \
@@ -407,6 +447,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Copyt", \
                           FALSE, \
+                          FALSE, \
                           1, 0, 1, 1, \
                           uplo, \
                           A, B )
@@ -416,6 +457,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Scal ", \
                           TRUE, \
+                          TRUE, \
                           0, 1, 0, 1, \
                           alpha, \
                           A )
@@ -424,6 +466,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Scalr_task, \
                           (void *) cntl, \
                           "Scalr", \
+                          TRUE, \
                           TRUE, \
                           1, 1, 0, 1, \
                           uplo, \
@@ -437,6 +480,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Buff ", \
                           FALSE, \
+                          FALSE, \
                           2, 0, 0, 1, \
                           rs, cs, \
                           A )
@@ -445,6 +489,7 @@ also to create a macro for when it is not below to return an error code.
         FLASH_Queue_push( (void *) FLA_Obj_free_buffer_task, \
                           (void *) cntl, \
                           "Free ", \
+                          FALSE, \
                           FALSE, \
                           0, 0, 0, 1, \
                           A )

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_main_prototypes.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_main_prototypes.h
@@ -65,13 +65,13 @@ void           FLASH_Queue_reset( void );
 FLASH_Task*    FLASH_Queue_get_head_task( void );
 FLASH_Task*    FLASH_Queue_get_tail_task( void );
 void           FLASH_Queue_push( void *func, void *cntl, char *name,
-                                 FLA_Bool enabled_gpu,
+                                 FLA_Bool enabled_gpu, FLA_Bool enabled_hip,
                                  int n_int_args, int n_fla_args,
                                  int n_input_args, int n_output_args, ... );
 void           FLASH_Queue_push_input( FLA_Obj obj, FLASH_Task* t );
 void           FLASH_Queue_push_output( FLA_Obj obj, FLASH_Task* t );
 FLASH_Task*    FLASH_Task_alloc( void *func, void *cntl, char *name,
-                                 FLA_Bool enabled_gpu,
+                                 FLA_Bool enabled_gpu, FLA_Bool enabled_hip,
                                  int n_int_args, int n_fla_args,
                                  int n_input_args, int n_output_args );
 void           FLASH_Task_free( FLASH_Task *t );
@@ -99,6 +99,19 @@ void           FLASH_Queue_mark_gpu( FLASH_Task *t, void *arg );
 void           FLASH_Queue_invalidate_block_gpu( FLA_Obj obj, int thread, void *arg );
 void           FLASH_Queue_flush_block_gpu( FLA_Obj obj, int thread, void *arg );
 void           FLASH_Queue_flush_gpu( int thread, void *arg );
+#endif
+#ifdef FLA_ENABLE_HIP
+void           FLASH_Queue_create_hip( int thread, void *arg );
+void           FLASH_Queue_destroy_hip( int thread, void *arg );
+FLA_Bool       FLASH_Queue_exec_hip( FLASH_Task *t, void *arg );
+FLA_Bool       FLASH_Queue_check_hip( FLASH_Task *t, void *arg );
+FLA_Bool       FLASH_Queue_check_block_hip( FLA_Obj obj, int thread, void *arg );
+void           FLASH_Queue_update_hip( FLASH_Task *t, void **input_arg, void **output_arg, void *arg );
+void           FLASH_Queue_update_block_hip( FLA_Obj obj, void **buffer_gpu, int thread, void *arg );
+void           FLASH_Queue_mark_hip( FLASH_Task *t, void *arg );
+void           FLASH_Queue_invalidate_block_hip( FLA_Obj obj, int thread, void *arg );
+void           FLASH_Queue_flush_block_hip( FLA_Obj obj, int thread, void *arg );
+void           FLASH_Queue_flush_hip( int thread, void *arg );
 #endif
 void           FLASH_Queue_exec_parallel( void *arg );
 void*          FLASH_Queue_exec_parallel_function( void *arg );

--- a/src/base/flamec/supermatrix/main/FLASH_Queue.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue.c
@@ -255,6 +255,10 @@ void FLASH_Queue_init( void )
    FLASH_Queue_init_gpu();
 #endif
 
+#ifdef FLA_ENABLE_HIP
+   FLASH_Queue_init_hip();
+#endif
+
    return;
 }
 
@@ -275,6 +279,10 @@ void FLASH_Queue_finalize( void )
 
 #ifdef FLA_ENABLE_GPU
    FLASH_Queue_finalize_gpu();
+#endif
+
+#ifdef FLA_ENABLE_HIP
+   FLASH_Queue_finalize_hip();
 #endif
 
    return;
@@ -626,6 +634,7 @@ void FLASH_Queue_push( void* func,
                        void* cntl,
                        char* name,
                        FLA_Bool enabled_gpu,
+                       FLA_Bool enabled_hip,
                        int n_int_args,
                        int n_fla_args,
                        int n_input_args,
@@ -644,7 +653,7 @@ void FLASH_Queue_push( void* func,
 
    // Allocate a new FLA_Task and populate its fields with appropriate values.
    t = FLASH_Task_alloc( func, cntl, name, enabled_gpu,
-                         n_int_args, n_fla_args,
+                         enabled_hip, n_int_args, n_fla_args,
                          n_input_args, n_output_args );
    
    // Initialize variable argument environment. In case you're wondering, the
@@ -957,6 +966,7 @@ FLASH_Task* FLASH_Task_alloc( void *func,
                               void *cntl,
                               char *name,
                               FLA_Bool enabled_gpu,
+                              FLA_Bool enabled_hip,
                               int n_int_args,
                               int n_fla_args,
                               int n_input_args,
@@ -997,6 +1007,7 @@ FLASH_Task* FLASH_Task_alloc( void *func,
    t->cntl          = cntl;
    t->name          = name;
    t->enabled_gpu   = enabled_gpu;
+   t->enabled_hip   = enabled_hip;
    t->n_int_args    = n_int_args;
    t->n_fla_args    = n_fla_args;
    t->n_input_args  = n_input_args;


### PR DESCRIPTION
Implement HIP FLASH queue akin to the GPU reference.
Add enable_hip to macro definitions and tasks.
Add documentation of HIP queue functions.

Missing: hookups of HIP queue to base FLASH queue.

Depends on #56 