### PR TITLE
Fix formatting modifiers for algorithmic block sizes.

### DIFF
--- a/src/blas/1/axpy/front/flamec/test/flash/test_Axpy.c
+++ b/src/blas/1/axpy/front/flamec/test/flash/test_Axpy.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/axpy/front/flamec/test/flash_sm/test_Axpy.c
+++ b/src/blas/1/axpy/front/flamec/test/flash_sm/test_Axpy.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/axpyt/front/flamec/test/flash/test_Axpyt.c
+++ b/src/blas/1/axpyt/front/flamec/test/flash/test_Axpyt.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/axpyt/front/flamec/test/flash_sm/test_Axpyt.c
+++ b/src/blas/1/axpyt/front/flamec/test/flash_sm/test_Axpyt.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/copy/front/flamec/test/flash/test_Copy.c
+++ b/src/blas/1/copy/front/flamec/test/flash/test_Copy.c
@@ -59,8 +59,8 @@ int main(int argc, char *argv[])
 
 
   fprintf( stdout, "%c number of repeats: ", '%' );
-  scanf( "%d", &n_repeats );
-  fprintf( stdout, "%c %d\n", '%', n_repeats );
+  scanf( "%lu", &n_repeats );
+  fprintf( stdout, "%c %lu\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%d", &nb_alg );

--- a/src/blas/1/copy/front/flamec/test/flash/test_Copy.c
+++ b/src/blas/1/copy/front/flamec/test/flash/test_Copy.c
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     m_input, n_input,
     m, n,
     p_first, p_last, p_inc,
@@ -37,6 +36,8 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
+
+  dim_t nb_alg;
   
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
@@ -59,12 +60,12 @@ int main(int argc, char *argv[])
 
 
   fprintf( stdout, "%c number of repeats: ", '%' );
-  scanf( "%lu", &n_repeats );
-  fprintf( stdout, "%c %lu\n", '%', n_repeats );
+  scanf( "%d", &n_repeats );
+  fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/copy/front/flamec/test/flash_sm/test_Copy.c
+++ b/src/blas/1/copy/front/flamec/test/flash_sm/test_Copy.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/copy/front/flamec/test/flash_sm/test_Copy.c
+++ b/src/blas/1/copy/front/flamec/test/flash_sm/test_Copy.c
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     n_threads,
     m_input, n_input,
     m, n,
@@ -38,7 +37,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/blas/1/copyt/front/flamec/test/flash/test_Copyt.c
+++ b/src/blas/1/copyt/front/flamec/test/flash/test_Copyt.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/copyt/front/flamec/test/flash_sm/test_Copyt.c
+++ b/src/blas/1/copyt/front/flamec/test/flash_sm/test_Copyt.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/scal/front/flamec/test/flash/test_Scal.c
+++ b/src/blas/1/scal/front/flamec/test/flash/test_Scal.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/scal/front/flamec/test/flash_sm/test_Scal.c
+++ b/src/blas/1/scal/front/flamec/test/flash_sm/test_Scal.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/scalr/front/flamec/test/flash_sm/test_Scalr.c
+++ b/src/blas/1/scalr/front/flamec/test/flash_sm/test_Scalr.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/1/scalr/front/flamec/test/flash_sm/test_Scalr.c
+++ b/src/blas/1/scalr/front/flamec/test/flash_sm/test_Scalr.c
@@ -76,8 +76,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, n_input );
  
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/2/gemv/front/flamec/test/flash/test_Gemv.c
+++ b/src/blas/2/gemv/front/flamec/test/flash/test_Gemv.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/2/gemv/front/flamec/test/flash/test_Gemv.c
+++ b/src/blas/2/gemv/front/flamec/test/flash/test_Gemv.c
@@ -29,7 +29,6 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg,
     m_input, n_input,
     m, n,
     p_first, p_last, p_inc,
@@ -39,6 +38,8 @@ int main(int argc, char *argv[])
     i,
     n_param_combos = N_PARAM_COMBOS;
   int one = 1;
+
+  dim_t nb_alg;
   
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";

--- a/src/blas/2/gemv/front/flamec/test/flash_sm/test_Gemv.c
+++ b/src/blas/2/gemv/front/flamec/test/flash_sm/test_Gemv.c
@@ -29,7 +29,6 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg,
     n_threads,
     m_input, n_input,
     m, n,
@@ -40,7 +39,9 @@ int main(int argc, char *argv[])
     i,
     n_param_combos = N_PARAM_COMBOS;
   int one = 1;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/blas/2/gemv/front/flamec/test/flash_sm/test_Gemv.c
+++ b/src/blas/2/gemv/front/flamec/test/flash_sm/test_Gemv.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/2/trsv/front/flamec/test/flash/test_Trsv.c
+++ b/src/blas/2/trsv/front/flamec/test/flash/test_Trsv.c
@@ -30,7 +30,6 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg,
     m_input,
     m,
     p_first, p_last, p_inc,
@@ -40,7 +39,9 @@ int main(int argc, char *argv[])
     i,
     n_param_combos = N_PARAM_COMBOS;
   int one = 1;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/blas/2/trsv/front/flamec/test/flash/test_Trsv.c
+++ b/src/blas/2/trsv/front/flamec/test/flash/test_Trsv.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/2/trsv/front/flamec/test/flash_sm/test_Trsv.c
+++ b/src/blas/2/trsv/front/flamec/test/flash_sm/test_Trsv.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/2/trsv/front/flamec/test/flash_sm/test_Trsv.c
+++ b/src/blas/2/trsv/front/flamec/test/flash_sm/test_Trsv.c
@@ -30,7 +30,6 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg,
     n_threads,
     m_input,
     m,
@@ -41,7 +40,9 @@ int main(int argc, char *argv[])
     i,
     n_param_combos = N_PARAM_COMBOS;
   int one = 1;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/blas/3/gemm/front/flamec/test/flash_sm/test_Gemm.c
+++ b/src/blas/3/gemm/front/flamec/test/flash_sm/test_Gemm.c
@@ -69,8 +69,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/gemm/front/flamec/test/flash_sm/test_Gemm.c
+++ b/src/blas/3/gemm/front/flamec/test/flash_sm/test_Gemm.c
@@ -81,8 +81,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d %d\n", '%', m_input, k_input, n_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/hemm/front/flamec/test/flash_sm/test_Hemm.c
+++ b/src/blas/3/hemm/front/flamec/test/flash_sm/test_Hemm.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, n_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/hemm/front/flamec/test/flash_sm/test_Hemm.c
+++ b/src/blas/3/hemm/front/flamec/test/flash_sm/test_Hemm.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/her2k/front/flamec/test/flash_sm/test_Her2k.c
+++ b/src/blas/3/her2k/front/flamec/test/flash_sm/test_Her2k.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, k_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%d", &n_threads );
-  fprintf( stdout, "%c %d\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/her2k/front/flamec/test/flash_sm/test_Her2k.c
+++ b/src/blas/3/her2k/front/flamec/test/flash_sm/test_Her2k.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/herk/front/flamec/test/flash_sm/test_Herk.c
+++ b/src/blas/3/herk/front/flamec/test/flash_sm/test_Herk.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/herk/front/flamec/test/flash_sm/test_Herk.c
+++ b/src/blas/3/herk/front/flamec/test/flash_sm/test_Herk.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, k_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/symm/front/flamec/test/flash_sm/test_Symm.c
+++ b/src/blas/3/symm/front/flamec/test/flash_sm/test_Symm.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, n_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/symm/front/flamec/test/flash_sm/test_Symm.c
+++ b/src/blas/3/symm/front/flamec/test/flash_sm/test_Symm.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/syr2k/front/flamec/test/flash_sm/test_Syr2k.c
+++ b/src/blas/3/syr2k/front/flamec/test/flash_sm/test_Syr2k.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, k_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%d", &n_threads );
-  fprintf( stdout, "%c %d\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/syr2k/front/flamec/test/flash_sm/test_Syr2k.c
+++ b/src/blas/3/syr2k/front/flamec/test/flash_sm/test_Syr2k.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/syrk/front/flamec/test/flash_sm/test_Syrk.c
+++ b/src/blas/3/syrk/front/flamec/test/flash_sm/test_Syrk.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, k_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%d", &n_threads );
-  fprintf( stdout, "%c %d\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/syrk/front/flamec/test/flash_sm/test_Syrk.c
+++ b/src/blas/3/syrk/front/flamec/test/flash_sm/test_Syrk.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/trmm/front/flamec/test/flash_sm/test_Trmm.c
+++ b/src/blas/3/trmm/front/flamec/test/flash_sm/test_Trmm.c
@@ -68,8 +68,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/trmm/front/flamec/test/flash_sm/test_Trmm.c
+++ b/src/blas/3/trmm/front/flamec/test/flash_sm/test_Trmm.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, n_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%d", &n_threads );
-  fprintf( stdout, "%c %d\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/blas/3/trsm/front/flamec/test/flash_sm/test_Trsm.c
+++ b/src/blas/3/trsm/front/flamec/test/flash_sm/test_Trsm.c
@@ -68,8 +68,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/blas/3/trsm/front/flamec/test/flash_sm/test_Trsm.c
+++ b/src/blas/3/trsm/front/flamec/test/flash_sm/test_Trsm.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d\n", '%', m_input, n_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/lapack/dec/chol/front/flamec/test/flash/test_Chol.c
+++ b/src/lapack/dec/chol/front/flamec/test/flash/test_Chol.c
@@ -62,8 +62,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/chol/front/flamec/test/flash_sm/test_Chol.c
+++ b/src/lapack/dec/chol/front/flamec/test/flash_sm/test_Chol.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/lu/incpiv/front/flamec/test/flash/test_LU_incpiv.c
+++ b/src/lapack/dec/lu/incpiv/front/flamec/test/flash/test_LU_incpiv.c
@@ -65,12 +65,12 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/lu/incpiv/front/flamec/test/flash_sm/test_LU_incpiv.c
+++ b/src/lapack/dec/lu/incpiv/front/flamec/test/flash_sm/test_LU_incpiv.c
@@ -66,12 +66,12 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/q/caqrutinc/front/flamec/test/flash_sm/test_CAQR_UT_inc.c
+++ b/src/lapack/dec/q/caqrutinc/front/flamec/test/flash_sm/test_CAQR_UT_inc.c
@@ -61,12 +61,12 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/q/lqut/front/flamec/test/flash_sm/test_LQ_UT.c
+++ b/src/lapack/dec/q/lqut/front/flamec/test/flash_sm/test_LQ_UT.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &b_flash );
-  fprintf( stdout, "%c %u\n", '%', b_flash );
+  scanf( "%lu", &b_flash );
+  fprintf( stdout, "%c %lu\n", '%', b_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/q/qrut/front/flamec/test/flash_sm/test_QR_UT.c
+++ b/src/lapack/dec/q/qrut/front/flamec/test/flash_sm/test_QR_UT.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &b_flash );
-  fprintf( stdout, "%c %u\n", '%', b_flash );
+  scanf( "%lu", &b_flash );
+  fprintf( stdout, "%c %lu\n", '%', b_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/dec/q/qrutinc/front/flamec/test/flash_sm/test_QR_UT_inc.c
+++ b/src/lapack/dec/q/qrutinc/front/flamec/test/flash_sm/test_QR_UT_inc.c
@@ -67,12 +67,12 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/inv/spd/front/flamec/test/flash/test_SPDinv.c
+++ b/src/lapack/inv/spd/front/flamec/test/flash/test_SPDinv.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     m_input,
     m,
     p_first, p_last, p_inc,
@@ -36,7 +35,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkg";
   char *ticks  = "o+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/inv/spd/front/flamec/test/flash/test_SPDinv.c
+++ b/src/lapack/inv/spd/front/flamec/test/flash/test_SPDinv.c
@@ -61,8 +61,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/inv/spd/front/flamec/test/flash_sm/test_SPDinv.c
+++ b/src/lapack/inv/spd/front/flamec/test/flash_sm/test_SPDinv.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/inv/tri/front/flamec/test/flash/test_Trinv.c
+++ b/src/lapack/inv/tri/front/flamec/test/flash/test_Trinv.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     diag,
     m_input,
     m,
@@ -37,7 +36,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkg";
   char *ticks  = "o+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/inv/tri/front/flamec/test/flash/test_Trinv.c
+++ b/src/lapack/inv/tri/front/flamec/test/flash/test_Trinv.c
@@ -62,8 +62,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/inv/tri/front/flamec/test/flash_sm/test_Trinv.c
+++ b/src/lapack/inv/tri/front/flamec/test/flash_sm/test_Trinv.c
@@ -63,8 +63,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/inv/tri/front/flamec/test/flash_sm/test_Trinv.c
+++ b/src/lapack/inv/tri/front/flamec/test/flash_sm/test_Trinv.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     n_threads,
     diag,
     m_input,
@@ -38,7 +37,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkg";
   char *ticks  = "o+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/misc/ttmm/front/flamec/test/flash/test_Ttmm.c
+++ b/src/lapack/misc/ttmm/front/flamec/test/flash/test_Ttmm.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     m_input,
     m,
     p_first, p_last, p_inc,
@@ -36,7 +35,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkg";
   char *ticks  = "o+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/misc/ttmm/front/flamec/test/flash/test_Ttmm.c
+++ b/src/lapack/misc/ttmm/front/flamec/test/flash/test_Ttmm.c
@@ -61,8 +61,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/misc/ttmm/front/flamec/test/flash_sm/test_Ttmm.c
+++ b/src/lapack/misc/ttmm/front/flamec/test/flash_sm/test_Ttmm.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     n_threads,
     m_input,
     m,
@@ -37,7 +36,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkg";
   char *ticks  = "o+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/misc/ttmm/front/flamec/test/flash_sm/test_Ttmm.c
+++ b/src/lapack/misc/ttmm/front/flamec/test/flash_sm/test_Ttmm.c
@@ -62,8 +62,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/misc/uddateutinc/front/flamec/test/flash_sm/test_UDdate_UT_inc.c
+++ b/src/lapack/misc/uddateutinc/front/flamec/test/flash_sm/test_UDdate_UT_inc.c
@@ -78,8 +78,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d %d %d\n", '%', mB_input, mC_input, mD_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
   fprintf( stdout, "\nclear all;\n\n" );
 

--- a/src/lapack/misc/uddateutinc/front/flamec/test/flash_sm/test_UDdate_UT_inc.c
+++ b/src/lapack/misc/uddateutinc/front/flamec/test/flash_sm/test_UDdate_UT_inc.c
@@ -58,8 +58,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize:", '%' );
-  scanf( "%u", &b_alg );
-  fprintf( stdout, "%c %u\n", '%', b_alg );
+  scanf( "%lu", &b_alg );
+  fprintf( stdout, "%c %lu\n", '%', b_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &b_flash );

--- a/src/lapack/red/eig/gest/front/flamec/test/flash_sm/test_Eig_gest.c
+++ b/src/lapack/red/eig/gest/front/flamec/test/flash_sm/test_Eig_gest.c
@@ -78,8 +78,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', m_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%d", &n_threads );
-  fprintf( stdout, "%c %d\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
   fprintf( stdout, "\n" );
 

--- a/src/lapack/red/eig/gest/front/flamec/test/flash_sm/test_Eig_gest.c
+++ b/src/lapack/red/eig/gest/front/flamec/test/flash_sm/test_Eig_gest.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &b_flash );
-  fprintf( stdout, "%c %u\n", '%', b_flash );
+  scanf( "%lu", &b_flash );
+  fprintf( stdout, "%c %lu\n", '%', b_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/sol/lyap/front/flamec/test/flash_sm/test_Lyap.c
+++ b/src/lapack/sol/lyap/front/flamec/test/flash_sm/test_Lyap.c
@@ -69,8 +69,8 @@ int main( int argc, char *argv[] )
   fprintf( stdout, "%c %d\n", '%', sign );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &b_flash );
-  fprintf( stdout, "%c %u\n", '%', b_flash );
+  scanf( "%lu", &b_flash );
+  fprintf( stdout, "%c %lu\n", '%', b_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/sol/sylv/front/flamec/test/flash/test_Sylv.c
+++ b/src/lapack/sol/sylv/front/flamec/test/flash/test_Sylv.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/sol/sylv/front/flamec/test/flash/test_Sylv.c
+++ b/src/lapack/sol/sylv/front/flamec/test/flash/test_Sylv.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     m_input, n_input,
     m, n,
     p_first, p_last, p_inc,
@@ -36,6 +35,8 @@ int main(int argc, char *argv[])
     param_combo,
     i, j,
     n_param_combos = N_PARAM_COMBOS;
+
+  dim_t nb_alg;
 
   int sign;
   

--- a/src/lapack/sol/sylv/front/flamec/test/flash_sm/test_Sylv.c
+++ b/src/lapack/sol/sylv/front/flamec/test/flash_sm/test_Sylv.c
@@ -27,7 +27,6 @@ int main(int argc, char *argv[])
 {
   int 
     datatype,
-    nb_alg,
     n_threads,
     m_input, n_input,
     m, n,
@@ -37,6 +36,8 @@ int main(int argc, char *argv[])
     param_combo,
     i, j,
     n_param_combos = N_PARAM_COMBOS;
+
+  dim_t nb_alg;
 
   int sign;
   

--- a/src/lapack/sol/sylv/front/flamec/test/flash_sm/test_Sylv.c
+++ b/src/lapack/sol/sylv/front/flamec/test/flash_sm/test_Sylv.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/q2ut/front/flamec/test/flash/test_Apply_Q2_UT.c
+++ b/src/lapack/util/app/q2ut/front/flamec/test/flash/test_Apply_Q2_UT.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &nb_flash );

--- a/src/lapack/util/app/q2ut/front/flamec/test/flash/test_Apply_Q2_UT.c
+++ b/src/lapack/util/app/q2ut/front/flamec/test/flash/test_Apply_Q2_UT.c
@@ -70,8 +70,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/q2ut/front/flamec/test/flash_sm/test_Apply_Q2_UT.c
+++ b/src/lapack/util/app/q2ut/front/flamec/test/flash_sm/test_Apply_Q2_UT.c
@@ -72,8 +72,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/q2ut/front/flamec/test/flash_sm/test_Apply_Q2_UT.c
+++ b/src/lapack/util/app/q2ut/front/flamec/test/flash_sm/test_Apply_Q2_UT.c
@@ -68,8 +68,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &nb_flash );

--- a/src/lapack/util/app/qudutinc/front/flamec/test/flash_sm/test_Apply_QUD_UT_inc.c
+++ b/src/lapack/util/app/qudutinc/front/flamec/test/flash_sm/test_Apply_QUD_UT_inc.c
@@ -63,8 +63,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %lu\n", '%', b_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &b_flash );
-  fprintf( stdout, "%c %u\n", '%', b_flash );
+  scanf( "%lu", &b_flash );
+  fprintf( stdout, "%c %lu\n", '%', b_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc:", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );
@@ -83,8 +83,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_rhs_input );
 
   fprintf( stdout, "%c enter the number of SuperMatrix threads: ", '%' );
-  scanf( "%u", &n_threads );
-  fprintf( stdout, "%c %u\n", '%', n_threads );
+  scanf( "%lu", &n_threads );
+  fprintf( stdout, "%c %lu\n", '%', n_threads );
 
 
   fprintf( stdout, "\nclear all;\n\n" );

--- a/src/lapack/util/app/qudutinc/front/flamec/test/flash_sm/test_Apply_QUD_UT_inc.c
+++ b/src/lapack/util/app/qudutinc/front/flamec/test/flash_sm/test_Apply_QUD_UT_inc.c
@@ -59,8 +59,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize:", '%' );
-  scanf( "%u", &b_alg );
-  fprintf( stdout, "%c %u\n", '%', b_alg );
+  scanf( "%lu", &b_alg );
+  fprintf( stdout, "%c %lu\n", '%', b_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &b_flash );

--- a/src/lapack/util/app/qut/front/flamec/test/flash/test_Apply_Q.c
+++ b/src/lapack/util/app/qut/front/flamec/test/flash/test_Apply_Q.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg, bm, bn,
+    bm, bn,
     m_input, n_input,
     m, n,
     p_first, p_last, p_inc,
@@ -38,7 +38,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/util/app/qut/front/flamec/test/flash/test_Apply_Q.c
+++ b/src/lapack/util/app/qut/front/flamec/test/flash/test_Apply_Q.c
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/qut/front/flamec/test/flash_sm/test_Apply_Q.c
+++ b/src/lapack/util/app/qut/front/flamec/test/flash_sm/test_Apply_Q.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%d", &nb_alg );
-  fprintf( stdout, "%c %d\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/qut/front/flamec/test/flash_sm/test_Apply_Q.c
+++ b/src/lapack/util/app/qut/front/flamec/test/flash_sm/test_Apply_Q.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
   int 
     datatype,
     precision,
-    nb_alg, bm, bn,
+    bm, bn,
     n_threads,
     m_input, n_input,
     m, n,
@@ -39,7 +39,9 @@ int main(int argc, char *argv[])
     param_combo,
     i,
     n_param_combos = N_PARAM_COMBOS;
-  
+ 
+  dim_t nb_alg;
+ 
   char *colors = "brkgmcbrkgmcbrkgmc";
   char *ticks  = "o+*xso+*xso+*xso+*xs";
   char m_dim_desc[14];

--- a/src/lapack/util/app/qutinc/front/flamec/test/flash/test_Apply_Q_UT_inc.c
+++ b/src/lapack/util/app/qutinc/front/flamec/test/flash/test_Apply_Q_UT_inc.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &nb_flash );

--- a/src/lapack/util/app/qutinc/front/flamec/test/flash/test_Apply_Q_UT_inc.c
+++ b/src/lapack/util/app/qutinc/front/flamec/test/flash/test_Apply_Q_UT_inc.c
@@ -69,8 +69,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );

--- a/src/lapack/util/app/qutinc/front/flamec/test/flash_sm/test_Apply_Q_UT_inc.c
+++ b/src/lapack/util/app/qutinc/front/flamec/test/flash_sm/test_Apply_Q_UT_inc.c
@@ -66,8 +66,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %d\n", '%', n_repeats );
 
   fprintf( stdout, "%c enter algorithmic blocksize: ", '%' );
-  scanf( "%u", &nb_alg );
-  fprintf( stdout, "%c %u\n", '%', nb_alg );
+  scanf( "%lu", &nb_alg );
+  fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
   scanf( "%u", &nb_flash );

--- a/src/lapack/util/app/qutinc/front/flamec/test/flash_sm/test_Apply_Q_UT_inc.c
+++ b/src/lapack/util/app/qutinc/front/flamec/test/flash_sm/test_Apply_Q_UT_inc.c
@@ -70,8 +70,8 @@ int main(int argc, char *argv[])
   fprintf( stdout, "%c %lu\n", '%', nb_alg );
 
   fprintf( stdout, "%c enter FLASH blocksize: ", '%' );
-  scanf( "%u", &nb_flash );
-  fprintf( stdout, "%c %u\n", '%', nb_flash );
+  scanf( "%lu", &nb_flash );
+  fprintf( stdout, "%c %lu\n", '%', nb_flash );
 
   fprintf( stdout, "%c enter problem size first, last, inc: ", '%' );
   scanf( "%d%d%d", &p_first, &p_last, &p_inc );


### PR DESCRIPTION
Details:
- algorithmic blocks are long unsigned ints, hence use %lu where
  applicable