### PR TITLE
Enable offloading Cholesky tasks through rocSOLVER.

### DIFF
--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -164,7 +164,7 @@ LDFLAGS      := @fla_c_prof_flags@ @LDFLAGS@ @FLIBS@
 endif
 endif
 ifeq (@fla_enable_hip@, yes)
-LDFLAGS      := -L/opt/rocm/lib -lrocblas -lamdhip64 $(LDFLAGS)
+LDFLAGS      := -L/opt/rocm/lib -lrocsolver -lrocblas -lamdhip64 $(LDFLAGS)
 endif
 
 

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -196,6 +196,16 @@ FLA_Error FLA_Bsvdd_external( FLA_Uplo uplo, FLA_Obj d, FLA_Obj e, FLA_Obj U, FL
 FLA_Error FLA_Svd_external( FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, FLA_Obj s, FLA_Obj U, FLA_Obj V );
 FLA_Error FLA_Svdd_external( FLA_Svd_type jobz, FLA_Obj A, FLA_Obj s, FLA_Obj U, FLA_Obj V );
 
+// --- external HIP prototypes -------------------------------------------------
+#ifdef FLA_ENABLE_HIP
+FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_l_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+#endif
+
 // --- check routine prototypes ------------------------------------------------
 
 FLA_Error FLA_Chol_check( FLA_Uplo uplo, FLA_Obj A );

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -238,6 +238,9 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
 {
    // Define local function pointer types.
 
+   // LAPACK
+   typedef FLA_Error(*flash_chol_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, fla_chol_t* cntl);
+
    // Level-3 BLAS
    typedef FLA_Error(*flash_gemm_hip_p)(rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
    typedef FLA_Error(*flash_hemm_hip_p)(rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
@@ -265,8 +268,21 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
 
    // Now "switch" between the various possible task functions.
 
+   // FLA_Chol
+   if ( t-> func == (void*) FLA_Chol_task )
+   {
+      flash_chol_hip_p func;
+      func = (flash_chol_hip_p) FLA_Chol_blk_external_hip;
+
+      func(
+                            handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+                            t->output_arg[0],
+                            output_arg[0],
+            ( fla_chol_t* ) t->cntl );
+   }
    // FLA_Gemm
-   if ( t->func == (void *) FLA_Gemm_task )
+   else if ( t->func == (void *) FLA_Gemm_task )
    {
       flash_gemm_hip_p func;
       func = (flash_gemm_hip_p) FLA_Gemm_external_hip;

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -136,7 +136,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Chol ", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           1, 0, 0, 1, \
                           uplo, \
                           A )

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
@@ -1,0 +1,102 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Chol_l_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Chol_blk_external_hip( handle, FLA_LOWER_TRIANGULAR, A, A_hip ); 
+}
+
+FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Chol_blk_external_hip( handle, FLA_UPPER_TRIANGULAR, A, A_hip );
+}
+
+FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A;
+  int          ldim_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Chol_check( uplo, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    rocsolver_spotrf( handle,
+                      blas_uplo,
+                      n_A,
+                      ( float * ) A_hip, ldim_A,
+                      info );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    rocsolver_dpotrf( handle,
+                      blas_uplo,
+                      n_A,
+                      ( double * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocsolver_cpotrf( handle,
+                      blas_uplo,
+                      n_A,
+                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocsolver_zpotrf( handle,
+                      blas_uplo,
+                      n_A,
+                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  }
+  hipFree( info );
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
@@ -1,0 +1,102 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Chol_unb_external_hip( handle, FLA_LOWER_TRIANGULAR, A, A_hip ); 
+}
+
+FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Chol_unb_external_hip( handle, FLA_UPPER_TRIANGULAR, A, A_hip );
+}
+
+FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A;
+  int          ldim_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Chol_check( uplo, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    rocsolver_spotf2( handle,
+                      blas_uplo,
+                      n_A,
+                      ( float * ) A_hip, ldim_A,
+                      info );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    rocsolver_dpotf2( handle,
+                      blas_uplo,
+                      n_A,
+                      ( double * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocsolver_cpotf2( handle,
+                      blas_uplo,
+                      n_A,
+                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocsolver_zpotf2( handle,
+                      blas_uplo,
+                      n_A,
+                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  }
+  hipFree(info);
+
+  return FLA_SUCCESS;
+}
+
+#endif


### PR DESCRIPTION
Details:
- Unconditionally link against rocSOLVER if HIP is enabled.
- Provide wrappers for blocked and unblocked Cholesky decompositions
  (potrf, potf2) and lower/upper APIs.
- Enable Cholesky tasks for HIP offloading.