### PR TITLE
Correct mapping of FLA_Trans to rocblas_operation.

### DIFF
--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -347,7 +347,7 @@ void          FLA_Param_map_flame_to_netlib_svd_type( FLA_Svd_type svd_type, voi
 void          FLA_Param_map_flame_to_netlib_machval( FLA_Machval machval, void* blas_machval );
 
 #ifdef FLA_ENABLE_HIP
-rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans );
+rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans, FLA_Bool is_real );
 rocblas_fill      FLA_Param_map_flame_to_rocblas_uplo( FLA_Uplo uplo );
 rocblas_side      FLA_Param_map_flame_to_rocblas_side( FLA_Side side );
 rocblas_diagonal  FLA_Param_map_flame_to_rocblas_diag( FLA_Diag diag );

--- a/src/base/flamec/main/FLA_Param.c
+++ b/src/base/flamec/main/FLA_Param.c
@@ -48,24 +48,39 @@ void FLA_Param_map_flame_to_netlib_trans( FLA_Trans trans, void* blas_trans )
 }
 
 #ifdef FLA_ENABLE_HIP
-rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans)
+rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans, FLA_Bool is_real )
 {
-	if ( trans == FLA_NO_TRANSPOSE )
-	{
-		return rocblas_operation_none;
-	} else if ( trans == FLA_TRANSPOSE )
-	{
-		return rocblas_operation_transpose;
-	}
-	else if ( trans == FLA_CONJ_TRANSPOSE )
-	{
-		return rocblas_operation_conjugate_transpose;
-	}
-	else
-	{
-		FLA_Check_error_code( FLA_INVALID_TRANS );
-		return rocblas_operation_none; // to silence warning
-	}
+        if ( trans == FLA_NO_TRANSPOSE )
+        {
+                return rocblas_operation_none;
+        } else if ( trans == FLA_TRANSPOSE )
+        {
+                return rocblas_operation_transpose;
+        }
+        else if ( trans == FLA_CONJ_TRANSPOSE && is_real)
+        {
+                return rocblas_operation_transpose;
+        }
+        else if ( trans == FLA_CONJ_NO_TRANSPOSE && is_real )
+        {
+                return rocblas_operation_none;
+        }
+        else if ( trans == FLA_CONJ_TRANSPOSE && !is_real)
+        {
+                return rocblas_operation_conjugate_transpose;
+        }
+        else if ( trans == FLA_CONJ_NO_TRANSPOSE && !is_real)
+        {
+                // not supported by rocBLAS
+                fprintf( stderr, "FLA_CONJ_NO_TRANSPOSE not supported by rocBLAS.\n" );
+                FLA_Check_error_code( FLA_INVALID_TRANS );
+                return rocblas_operation_none; // to silence warning
+        }
+        else
+        {
+                FLA_Check_error_code( FLA_INVALID_TRANS );
+                return rocblas_operation_none; // to silence warning
+        }
 }
 #endif
 

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -37,7 +37,7 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
   inc_x    = 1;
   inc_y    = 1;
 
-  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa );
+  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa, FLA_Obj_is_real( A ) );
 
 
   switch( datatype ){

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   inc_x    = 1;
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -53,8 +53,8 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
   else
     k_AB = m_A;
 
-  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa );
-  rocblas_operation blas_transb = FLA_Param_map_flame_to_rocblas_trans( transb );
+  rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa, FLA_Obj_is_real( A ) );
+  rocblas_operation blas_transb = FLA_Param_map_flame_to_rocblas_trans( transb, FLA_Obj_is_real( B ) );
 
 
   switch( datatype ){

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -41,12 +41,12 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   m_C      = FLA_Obj_length( C );
   ldim_C   = FLA_Obj_length( C );
 
-  if ( trans == FLA_NO_TRANSPOSE )
+  if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_AB = n_A;
   else
     k_AB = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -38,12 +38,12 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   m_C      = FLA_Obj_length( C );
   ldim_C   = FLA_Obj_length( C );
 
-  if ( trans == FLA_NO_TRANSPOSE )
+  if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_A = n_A;
   else
     k_A = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -41,12 +41,12 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   m_C      = FLA_Obj_length( C );
   ldim_C   = FLA_Obj_length( C );
 
-  if ( trans == FLA_NO_TRANSPOSE )
+  if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_AB = n_A;
   else
     k_AB = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -38,12 +38,12 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   m_C      = FLA_Obj_length( C );
   ldim_C   = FLA_Obj_length( C );
 
-  if ( trans == FLA_NO_TRANSPOSE )
+  if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_A = n_A;
   else
     k_A = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   n_B      = FLA_Obj_width( B );
   ldim_B   = FLA_Obj_length( B );
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   n_B      = FLA_Obj_width( B );
   ldim_B   = FLA_Obj_length( B );
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );


### PR DESCRIPTION
Details:
- control trees sometimes unconditionally set FLA_CONJ_NO_TRANS even
  when the matrix is real. This is mathematically correct.
- rocBLAS gets confused in this case
- hence, introduce a is_real conditional to the mapping and return the
  "real type" rocblas_operation even for FLA_CONJ_* being passed.
- correct in some interfaces dimensions that also did not check for
  FLA_CONJ_* along side FLA_*_TRANSPOSE
- with this, all [s,d] tests pass on HIP