### PR TITLE
Introduce a FLA_buff_malloc() API.

### DIFF
--- a/src/base/flamec/hierarchy/main/FLASH_Obj.c
+++ b/src/base/flamec/hierarchy/main/FLASH_Obj.c
@@ -655,7 +655,7 @@ void FLASH_Obj_free( FLA_Obj* H )
 #ifdef FLA_ENABLE_SCC
 		FLA_shfree( buffer_H );
 #else
-		FLA_free( buffer_H );
+		FLA_buff_free( buffer_H );
 #endif
 
 		// All that remains now is to free the interior of the matrix hierarchy.

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -180,7 +180,9 @@ FLA_Bool      FLA_Memory_leak_counter_set( FLA_Bool new_status );
 
 void*         FLA_malloc( size_t size );
 void*         FLA_realloc( void* old_ptr, size_t size );
+void*         FLA_buff_malloc( size_t size );
 void          FLA_free( void *ptr );
+void          FLA_buff_free( void *ptr );
  
 
 

--- a/src/base/flamec/main/FLA_Obj.c
+++ b/src/base/flamec/main/FLA_Obj.c
@@ -107,7 +107,7 @@ FLA_Error FLA_Obj_create_ext( FLA_Datatype datatype, FLA_Elemtype elemtype, dim_
 #ifdef FLA_ENABLE_SCC
   obj->base->buffer = ( FLA_Obj_elemtype( *obj ) == FLA_MATRIX ? FLA_malloc( buffer_size ) : FLA_shmalloc( buffer_size ) );
 #else
-  obj->base->buffer = FLA_malloc( buffer_size );
+  obj->base->buffer = FLA_buff_malloc( buffer_size );
 #endif
   obj->base->buffer_info = 0;
 
@@ -569,7 +569,7 @@ FLA_Error FLA_Obj_create_buffer( dim_t rs, dim_t cs, FLA_Obj *obj )
 #ifdef FLA_ENABLE_SCC
   obj->base->buffer = ( FLA_Obj_elemtype( *obj ) == FLA_MATRIX ? FLA_malloc( buffer_size ) : FLA_shmalloc( buffer_size ) );
 #else
-  obj->base->buffer = FLA_malloc( buffer_size );
+  obj->base->buffer = FLA_buff_malloc( buffer_size );
 #endif
   obj->base->buffer_info = 0;
 
@@ -596,7 +596,7 @@ FLA_Error FLA_Obj_free( FLA_Obj *obj )
     ( FLA_Obj_elemtype( *obj ) == FLA_MATRIX ? FLA_free( obj->base->buffer ) : FLA_shfree( obj->base->buffer ) );
 #else
     //printf( "freeing buff %p\n", obj->base->buffer ); fflush( stdout );
-    FLA_free( obj->base->buffer );
+    FLA_buff_free( obj->base->buffer );
 #endif
     //printf( "freeing base %p\n", obj->base ); fflush( stdout );
     FLA_free( ( void * ) obj->base );
@@ -637,7 +637,7 @@ FLA_Error FLA_Obj_free_buffer( FLA_Obj *obj )
 #ifdef FLA_ENABLE_SCC
   ( FLA_Obj_elemtype( *obj ) == FLA_MATRIX ? FLA_free( obj->base->buffer ) : FLA_shfree( obj->base->buffer ) );
 #else
-  FLA_free( obj->base->buffer );
+  FLA_buff_free( obj->base->buffer );
 #endif
   obj->base->buffer = NULL;
 

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -195,13 +195,16 @@ FLA_Error FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip )
 ----------------------------------------------------------------------------*/
 {
    // Write the contents of a block in main memory to HIP.
-   rocblas_set_matrix( FLA_Obj_length( obj ),
-                       FLA_Obj_width( obj ),
-                       FLA_Obj_datatype_size( FLA_Obj_datatype( obj ) ),
-                       FLA_Obj_buffer_at_view( obj ), 
-                       FLA_Obj_col_stride( obj ),
-                       buffer_hip,
-                       FLA_Obj_length( obj ) );
+   hipStream_t stream;
+   rocblas_get_stream( handle, &stream );
+   rocblas_set_matrix_async( FLA_Obj_length( obj ),
+                             FLA_Obj_width( obj ),
+                             FLA_Obj_datatype_size( FLA_Obj_datatype( obj ) ),
+                             FLA_Obj_buffer_at_view( obj ),
+                             FLA_Obj_col_stride( obj ),
+                             buffer_hip,
+                             FLA_Obj_length( obj ),
+                             stream );
 
    return FLA_SUCCESS;
 }


### PR DESCRIPTION
Details:
    - In order to copy memory from host to HIP device or vice versa
      asynchronously (which has performance advantages), the host memory
      must be page-locked and device accessible. Allocation through
      hipHostMalloc() ensures this.
    - Allocating everything through hipHostMalloc() is not advisable as
      excessive page-locking can cause OS-level performance issues.
    - Hence, introduce a FLA_buff_malloc() API that, only for HIP, uses
      hipHostMalloc to allocate the host buffers. Companion FLA_buff_free()
      API frees the buffer through hipHostFree(). For non-HIP cases, calls
      are forwarded to FLA_malloc().
    - In turn, use async variant of rocblas_set_matrix (retain the
      synchronous rocblas_get_matrix as an implied synchronization point).
    - Follow-up will remove the implied compression of buffer data when
      going from host->device (and expansion device->host) to establish 1:1
      data layout mapping between host and device buffer.