### PR TITLE
Add GPU support for Trinv/trtri through rocSOLVER

### DIFF
--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -204,6 +204,12 @@ FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip 
 FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+
+FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_lu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_un_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -240,6 +240,7 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
 
    // LAPACK
    typedef FLA_Error(*flash_chol_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, fla_chol_t* cntl);
+   typedef FLA_Error(*flash_trinv_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip, fla_chol_t* cntl);
 
    // Level-3 BLAS
    typedef FLA_Error(*flash_gemm_hip_p)(rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
@@ -277,6 +278,20 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
       func(
                             handle,
             ( FLA_Uplo    ) t->int_arg[0],
+                            t->output_arg[0],
+                            output_arg[0],
+            ( fla_chol_t* ) t->cntl );
+   }
+   // FLA_Trinv
+   else if ( t-> func == (void*) FLA_Trinv_task )
+   {
+      flash_trinv_hip_p func;
+      func = (flash_trinv_hip_p) FLA_Trinv_blk_external_hip;
+
+      func(
+                            handle,
+            ( FLA_Uplo    ) t->int_arg[0],
+            ( FLA_Diag    ) t->int_arg[1],
                             t->output_arg[0],
                             output_arg[0],
             ( fla_chol_t* ) t->cntl );

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -116,7 +116,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Trinv", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           2, 0, 0, 1, \
                           uplo, diag, \
                           A )

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
@@ -1,0 +1,118 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+
+FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Trinv_blk_external_hip( handle, FLA_LOWER_TRIANGULAR, FLA_NONUNIT_DIAG, A, A_hip );
+}
+
+FLA_Error FLA_Trinv_lu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Trinv_blk_external_hip( handle, FLA_LOWER_TRIANGULAR, FLA_UNIT_DIAG, A, A_hip );
+}
+
+FLA_Error FLA_Trinv_un_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Trinv_blk_external_hip( handle, FLA_UPPER_TRIANGULAR, FLA_NONUNIT_DIAG, A, A_hip );
+}
+
+FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
+{
+  return FLA_Trinv_blk_external_hip( handle, FLA_UPPER_TRIANGULAR, FLA_UNIT_DIAG, A, A_hip );
+}
+
+FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A;
+  int          ldim_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Chol_check( uplo, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  ldim_A   = FLA_Obj_length( A );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    rocsolver_strtri( handle,
+                      blas_uplo,
+                      blas_diag,
+                      n_A,
+                      ( float * ) A_hip, ldim_A,
+                      info );
+    
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    rocsolver_dtrtri( handle,
+                      blas_uplo,
+                      blas_diag,
+                      n_A,
+                      ( double * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocsolver_ctrtri( handle,
+                      blas_uplo,
+                      blas_diag,
+                      n_A,
+                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocsolver_ztrtri( handle,
+                      blas_uplo,
+                      blas_diag,
+                      n_A,
+                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      info );
+
+    break;
+  }
+
+  }
+  hipFree( info );
+
+  return FLA_SUCCESS;
+}
+
+#endif


### PR DESCRIPTION
Details:
- use rocSOLVER's [s/d/c/z]trtri implementation to provide
  blocked Trinv support for HIP.