### PR TITLE
Multithreading must be on for HIP acceleration.

### DIFF
--- a/build/ac-macros/fla_require_multithreading_enabled.m4
+++ b/build/ac-macros/fla_require_multithreading_enabled.m4
@@ -1,0 +1,16 @@
+AC_DEFUN([FLA_REQUIRE_MULTITHREADING_ENABLED],
+[
+	AC_REQUIRE([FLA_CHECK_ENABLE_SUPERMATRIX])
+	AC_REQUIRE([FLA_CHECK_ENABLE_MULTITHREADING])
+	AC_REQUIRE([FLA_CHECK_ENABLE_HIP])
+
+	dnl Make sure the user did request multithreading if HIP is
+	dnl enabled.
+
+	dnl Scenario 1: User wants HIP support but forgot to enable multithreading.
+	if test "$fla_enable_hip" = "yes" ; then
+		if test "$fla_enable_multithreading" = "no" ; then
+			AC_MSG_ERROR([Configuring libflame to enable HIP support without also enabling multithreading is not allowed. HIP utilization requires that multithreading be enabled. Please adjust your configure options accordingly and then re-run configure.],[1])
+		fi
+	fi
+])

--- a/configure
+++ b/configure
@@ -7037,6 +7037,19 @@ printf "%s\n" "no" >&6; }
 
 
 
+
+		if test "$fla_enable_hip" = "yes" ; then
+		if test "$fla_enable_multithreading" = "no" ; then
+			as_fn_error 1 "Configuring libflame to enable HIP support without also enabling multithreading is not allowed. HIP utilization requires that multithreading be enabled. Please adjust your configure options accordingly and then re-run configure." "$LINENO" 5
+		fi
+	fi
+
+
+
+
+
+
+
 		if test "$fla_enable_gpu" = "yes" ; then
 		if test "$fla_enable_hip" = "yes" ; then
 			as_fn_error 1 "Configuring libflame to enable GPU and HIP support is not allowed. Please adjust your configure options accordingly and then re-run configure." "$LINENO" 5

--- a/configure.ac
+++ b/configure.ac
@@ -470,6 +470,9 @@ dnl Make sure the user did not request a weird combination of parallelization
 dnl options.
 FLA_REQUIRE_SUPERMATRIX_ENABLED
 
+dnl Make sure the user enabled multithreading if HIP is enabled.
+FLA_REQUIRE_MULTITHREADING_ENABLED
+
 dnl Make sure the user did not request both GPU and HIP options.
 FLA_REQUIRE_NOT_HIP_AND_GPU_ENABLED
 

--- a/docs/libflame/23-setup-linux.tex
+++ b/docs/libflame/23-setup-linux.tex
@@ -536,6 +536,8 @@ Note that this option is experimental.
 Enable code that takes advantage of AMD accelerators/GPUs through HIP when
 performing certain computations.
 If enabled, SuperMatrix must also be enabled via {\tt --enable-supermatrix}.
+If enbaled, multithreading must also be enabled via {\tt --enable-multithreading},
+{\tt pthreads} is recommended.
 Note that this option is experimental.
 {\em Disabled by default.}
 }


### PR DESCRIPTION
Details:
- Without multithreading on, SuperMatrix will use the non-accelerated
  simulation path.
- Add a configure-time check that multithreading was enabled.
- Document this requirement with a recommendation of posix threads.