### PR TITLE
Copy buffers directly to HIP devices.

### DIFF
--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
@@ -25,12 +25,12 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
 
   FLA_Datatype datatype = FLA_Obj_datatype( A );
 
-  rocblas_stride ldim_A = FLA_Obj_length( A );
+  rocblas_stride ldim_A = FLA_Obj_col_stride( A );
   rocblas_int inc_A     = 1;
 
   rocblas_int m_B       = FLA_Obj_length( B );
   rocblas_int n_B       = FLA_Obj_width( B );
-  rocblas_stride ldim_B = FLA_Obj_length( B );
+  rocblas_stride ldim_B = FLA_Obj_col_stride( B );
   rocblas_int inc_B     = 1;
 
   switch ( datatype ){

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
@@ -25,11 +25,11 @@ FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, 
   if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
 
   dim_t elem_size = FLA_Obj_elem_size( B );
-  dim_t ldim_A    = FLA_Obj_length( A );
+  dim_t ldim_A    = FLA_Obj_col_stride( A );
 
   dim_t m_B       = FLA_Obj_length( B );
   dim_t n_B       = FLA_Obj_width( B );
-  dim_t ldim_B    = FLA_Obj_length( B );
+  dim_t ldim_B    = FLA_Obj_col_stride( B );
 
   size_t dpitch   = elem_size * ldim_B;
   size_t spitch   = elem_size * ldim_A;

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
@@ -36,7 +36,7 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
   inc_A    = 1;
 
   switch ( datatype ){

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
@@ -36,7 +36,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
   inc_A    = 1;
 
   if ( uplo == FLA_LOWER_TRIANGULAR ){

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -32,7 +32,7 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   inc_x    = 1;
   inc_y    = 1;

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -30,7 +30,7 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   datatype = FLA_Obj_datatype( A );
 
   m_A      = FLA_Obj_length( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   inc_x    = 1;
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -40,13 +40,13 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   m_C      = FLA_Obj_length( C );
   n_C      = FLA_Obj_width( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   if ( transa == FLA_NO_TRANSPOSE || transa == FLA_CONJ_NO_TRANSPOSE )
     k_AB = n_A;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
@@ -30,13 +30,13 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   datatype = FLA_Obj_datatype( A );
 
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   m_C      = FLA_Obj_length( C );
   n_C      = FLA_Obj_width( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -34,12 +34,12 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   m_C      = FLA_Obj_length( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_AB = n_A;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -33,10 +33,10 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   m_C      = FLA_Obj_length( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_A = n_A;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
@@ -30,13 +30,13 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   datatype = FLA_Obj_datatype( A );
 
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   m_C      = FLA_Obj_length( C );
   n_C      = FLA_Obj_width( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -34,12 +34,12 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   m_C      = FLA_Obj_length( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_AB = n_A;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -33,10 +33,10 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   m_A      = FLA_Obj_length( A );
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   m_C      = FLA_Obj_length( C );
-  ldim_C   = FLA_Obj_length( C );
+  ldim_C   = FLA_Obj_col_stride( C );
 
   if ( trans == FLA_NO_TRANSPOSE || trans == FLA_CONJ_NO_TRANSPOSE )
     k_A = n_A;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -29,11 +29,11 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   datatype = FLA_Obj_datatype( A );
 
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   m_B      = FLA_Obj_length( B );
   n_B      = FLA_Obj_width( B );
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -29,11 +29,11 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   datatype = FLA_Obj_datatype( A );
 
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   m_B      = FLA_Obj_length( B );
   n_B      = FLA_Obj_width( B );
-  ldim_B   = FLA_Obj_length( B );
+  ldim_B   = FLA_Obj_col_stride( B );
 
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
@@ -41,7 +41,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   datatype = FLA_Obj_datatype( A );
 
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_int* info;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
@@ -41,7 +41,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   datatype = FLA_Obj_datatype( A );
 
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_int* info;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
@@ -52,7 +52,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
   datatype = FLA_Obj_datatype( A );
 
   n_A      = FLA_Obj_width( A );
-  ldim_A   = FLA_Obj_length( A );
+  ldim_A   = FLA_Obj_col_stride( A );
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );


### PR DESCRIPTION
 Details:
- Currently, buffers are copied through rocblas_[get/set]_device. These functions linearize the memory - after the operation stride is equal to length.
- This breaks data layout coherence between the CPU and the GPU buffers and, if strides are unequal length, penalizes the copy performance.
- Directly use hipMemcpyAsync (for write to device) and synchronous hipMemcpy (for read from device).
- Adapt rocBLAS and rocSOLVER wrappers to correctly pass the stride (instead of the length).