### PR TITLE
Enable use of managed memory for HIP.

### DIFF
--- a/docs/libflame/40-user-api.tex
+++ b/docs/libflame/40-user-api.tex
@@ -5930,6 +5930,63 @@ execution is disabled.
 }
 \end{flaspec}
 
+% --- FLASH_Queue_enable_malloc_managed_hip() ----------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+FLA_Error FLASH_Queue_enable_malloc_managed_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueueenablegpuns}
+\purpose{
+Enable allocation of buffers as managed memory. They will be used directly
+from HIP-enabled SuperMatrix tasks.
+}
+\rvalue{
+\flasuccess if SuperMatrix is enabled and a parallel region has not yet
+begun;
+\flafailure otherwise.
+}
+\end{flaspec}
+
+% --- FLASH_Queue_disable_malloc_managed_hip() ---------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+FLA_Error FLASH_Queue_disable_malloc_managed_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueueenablegpuns}
+\purpose{
+Disable allocation of buffers as managed memory. They will be used directly
+from HIP-enabled SuperMatrix tasks.
+}
+\rvalue{
+\flasuccess if SuperMatrix is enabled and a parallel region has not yet
+begun;
+\flafailure otherwise.
+}
+\end{flaspec}
+
+% --- FLASH_Queue_get_malloc_managed_enabled_hip -------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+FLA_Bool FLASH_Queue_get_malloc_managed_enabled_hip( void );
+\end{verbatim}
+\index{SuperMatrix functions!\flashqueuegetenabledgpuns}
+\purpose{
+Query whether managed memory for buffers is currently enabled.
+}
+\notes{
+If SuperMatrix is currently disabled, the function returns \false regardless
+of whether use of managed memory was previously enabled.
+}
+\rvalue{
+\true if SuperMatrix and managed memory are both enabled;
+\false if SuperMatrix is disabled, or if SuperMatrix is enabled but managed
+memory is disabled.
+}
+\end{flaspec}
+
 % --- FLASH_Queue_set_hip_num_blocks() -----------------------------------------
 
 \begin{flaspec}

--- a/src/base/flamec/main/FLA_Memory.c
+++ b/src/base/flamec/main/FLA_Memory.c
@@ -252,6 +252,19 @@ void* FLA_buff_malloc( size_t size )
 #ifdef FLA_ENABLE_HIP
   if ( FLASH_Queue_get_enabled_hip( ) )
   {
+    if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+    {
+      // use hipMallocManaged to allocate buffers that are managed by HMM
+      void* ptr = NULL;
+      hipError_t err = hipMallocManaged(&ptr, size, hipMemAttachGlobal);
+      if ( err != hipSuccess )
+      {
+        fprintf( stderr, "libflame: failure to allocate %ld bytes through hipMallocManaged\n",
+          size );
+        fflush( stderr );
+      }
+      return ptr;
+    }
     // use hipHostMalloc to allocate buffers that are device accessible and
     // page locked - only if HIP is enabled and we anticipate needing data in
     // these buffers on device
@@ -315,6 +328,16 @@ void FLA_buff_free( void* ptr )
 #ifdef FLA_ENABLE_HIP
   if ( FLASH_Queue_get_enabled_hip( ) )
   {
+    if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+    {
+      hipError_t err = hipFree( ptr );
+      if ( err != hipSuccess )
+      {
+        fprintf( stderr, "libflame: failure to free through hipFree\n" );
+        fflush( stderr );
+      }
+      return;
+    }
     hipError_t err = hipHostFree( ptr );
     if ( err != hipSuccess )
     {

--- a/src/base/flamec/main/FLA_Memory.c
+++ b/src/base/flamec/main/FLA_Memory.c
@@ -256,7 +256,7 @@ void* FLA_buff_malloc( size_t size )
     {
       // use hipMallocManaged to allocate buffers that are managed by HMM
       void* ptr = NULL;
-      hipError_t err = hipMallocManaged(&ptr, size, hipMemAttachGlobal);
+      hipError_t err = hipMallocManaged( &ptr, size, hipMemAttachGlobal );
       if ( err != hipSuccess )
       {
         fprintf( stderr, "libflame: failure to allocate %ld bytes through hipMallocManaged\n",

--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -25,6 +25,10 @@ FLA_Bool       FLASH_Queue_get_enabled_hip( void );
 
 // --- helper functions -------------------------------------------------------
 
+FLA_Error      FLASH_Queue_enable_malloc_managed_hip( void );
+FLA_Error      FLASH_Queue_disable_malloc_managed_hip( void );
+FLA_Bool       FLASH_Queue_get_malloc_managed_enabled_hip( void );
+
 void           FLASH_Queue_set_hip_num_blocks( dim_t n_blocks );
 dim_t          FLASH_Queue_get_hip_num_blocks( void );
 

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
@@ -33,13 +33,26 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   rocblas_stride ldim_B = FLA_Obj_col_stride( B );
   rocblas_int inc_B     = 1;
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+  }
+
   switch ( datatype ){
 
   case FLA_FLOAT:
   {
     float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
-    float* buff_A_hip = ( float* ) A_hip;
-    float* buff_B_hip = ( float* ) B_hip;
+    float* buff_A_hip = ( float* ) A_mat;
+    float* buff_B_hip = ( float* ) B_mat;
 
     rocblas_status err = rocblas_saxpy_strided_batched( handle,
                                    m_B,
@@ -65,8 +78,8 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_DOUBLE:
   {
     double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
-    double* buff_A_hip = ( double* ) A_hip;
-    double* buff_B_hip = ( double* ) B_hip;
+    double* buff_A_hip = ( double* ) A_mat;
+    double* buff_B_hip = ( double* ) B_mat;
 
     rocblas_status err = rocblas_daxpy_strided_batched( handle,
                                    m_B,
@@ -92,8 +105,8 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_COMPLEX:
   {
     rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
-    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
-    rocblas_float_complex* buff_B_hip = ( rocblas_float_complex* ) B_hip;
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_mat;
+    rocblas_float_complex* buff_B_hip = ( rocblas_float_complex* ) B_mat;
 
     rocblas_status err = rocblas_caxpy_strided_batched( handle,
                                    m_B,
@@ -119,8 +132,8 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_DOUBLE_COMPLEX:
   {
     rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
-    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
-    rocblas_double_complex* buff_B_hip = ( rocblas_double_complex* ) B_hip;
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_mat;
+    rocblas_double_complex* buff_B_hip = ( rocblas_double_complex* ) B_mat;
 
     rocblas_status err = rocblas_zaxpy_strided_batched( handle,
                                    m_B,

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
 
   void* A_mat = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
@@ -38,7 +38,7 @@ FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, 
 
   void* A_mat = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
@@ -36,12 +36,25 @@ FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, 
   size_t width    = elem_size * m_B;
   size_t height   = n_B;
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+  }
+
   hipStream_t stream;
   rocblas_get_stream( handle, &stream );
   // hipMemcpy2D assumes row-major layout
-  hipError_t err = hipMemcpy2DAsync( B_hip,
+  hipError_t err = hipMemcpy2DAsync( B_mat,
                                      dpitch,
-                                     A_hip,
+                                     A_mat,
                                      spitch,
                                      width,
                                      height,

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   inc_A    = 1;
 
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
   }

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
@@ -39,12 +39,22 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   ldim_A   = FLA_Obj_col_stride( A );
   inc_A    = 1;
 
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
   switch ( datatype ){
 
   case FLA_FLOAT:
   {
     float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
-    float* buff_A_hip = ( float* ) A_hip;
+    float* buff_A_hip = ( float* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_sscal( handle,
@@ -58,7 +68,7 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_DOUBLE:
   {
     double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
-    double* buff_A_hip = ( double* ) A_hip;
+    double* buff_A_hip = ( double* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_dscal( handle,
@@ -72,7 +82,7 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_COMPLEX:
   {
     rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
-    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_cscal( handle,
@@ -86,7 +96,7 @@ FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
   case FLA_DOUBLE_COMPLEX:
   {
     rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
-    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_zscal( handle,

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
@@ -39,6 +39,16 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   ldim_A   = FLA_Obj_col_stride( A );
   inc_A    = 1;
 
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
   if ( uplo == FLA_LOWER_TRIANGULAR ){
 
   switch ( datatype ){
@@ -46,7 +56,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_FLOAT:
   {
     float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
-    float* buff_A_hip = ( float* ) A_hip;
+    float* buff_A_hip = ( float* ) A_mat;
 
     for ( i = 0; i < min( n_A, m_A ); i++ )
       rocblas_sscal( handle,
@@ -60,7 +70,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_DOUBLE:
   {
     double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
-    double* buff_A_hip = ( double* ) A_hip;
+    double* buff_A_hip = ( double* ) A_mat;
 
     for ( i = 0; i < min( n_A, m_A ); i++ )
       rocblas_dscal( handle,
@@ -74,7 +84,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_COMPLEX:
   {
     rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
-    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_mat;
 
     for ( i = 0; i < min( n_A, m_A ); i++ )
       rocblas_cscal( handle,
@@ -88,7 +98,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_DOUBLE_COMPLEX:
   {
     rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
-    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_mat;
 
     for ( i = 0; i < min( n_A, m_A ); i++ )
       rocblas_zscal( handle,
@@ -110,7 +120,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_FLOAT:
   {
     float* buff_alpha = ( float* ) FLA_FLOAT_PTR( alpha );
-    float* buff_A_hip = ( float* ) A_hip;
+    float* buff_A_hip = ( float* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_sscal( handle,
@@ -124,7 +134,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_DOUBLE:
   {
     double* buff_alpha = ( double* ) FLA_DOUBLE_PTR( alpha );
-    double* buff_A_hip = ( double* ) A_hip;
+    double* buff_A_hip = ( double* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_dscal( handle,
@@ -138,7 +148,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_COMPLEX:
   {
     rocblas_float_complex* buff_alpha = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( alpha );
-    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_hip;
+    rocblas_float_complex* buff_A_hip = ( rocblas_float_complex* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_cscal( handle,
@@ -152,7 +162,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   case FLA_DOUBLE_COMPLEX:
   {
     rocblas_double_complex* buff_alpha = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( alpha );
-    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_hip;
+    rocblas_double_complex* buff_A_hip = ( rocblas_double_complex* ) A_mat;
 
     for ( i = 0; i < n_A; i++ )
       rocblas_zscal( handle,

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj 
   inc_A    = 1;
 
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
   }

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -39,6 +39,21 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
 
   rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa, FLA_Obj_is_real( A ) );
 
+  void* A_mat = NULL;
+  void* x_vec = NULL;
+  void* y_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    x_vec = FLA_Obj_buffer_at_view( x );
+    y_vec = FLA_Obj_buffer_at_view( y );
+  }
+  else
+  {
+    A_mat = A_hip;
+    x_vec = x_hip;
+    y_vec = y_hip;
+  }
 
   switch( datatype ){
   
@@ -52,10 +67,10 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
                    m_A,
                    n_A, 
                    buff_alpha,                   
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) x_hip, inc_x,
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) x_vec, inc_x,
                    buff_beta,
-                   ( float * ) y_hip, inc_y );
+                   ( float * ) y_vec, inc_y );
 
     break;
   }
@@ -70,10 +85,10 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
                    m_A,
                    n_A, 
                    buff_alpha,                   
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) x_hip, inc_x,
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) x_vec, inc_x,
                    buff_beta,
-                   ( double * ) y_hip, inc_y );
+                   ( double * ) y_vec, inc_y );
 
     break;
   }
@@ -88,10 +103,10 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
                    m_A,
                    n_A, 
                    buff_alpha,                   
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) x_hip, inc_x,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) x_vec, inc_x,
                    buff_beta,
-                   ( rocblas_float_complex * ) y_hip, inc_y );
+                   ( rocblas_float_complex * ) y_vec, inc_y );
 
     break;
   }
@@ -106,10 +121,10 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
                    m_A,
                    n_A, 
                    buff_alpha,                   
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) x_hip, inc_x,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) x_vec, inc_x,
                    buff_beta,
-                   ( rocblas_double_complex * ) y_hip, inc_y );
+                   ( rocblas_double_complex * ) y_vec, inc_y );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -42,7 +42,7 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
   void* A_mat = NULL;
   void* x_vec = NULL;
   void* y_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     x_vec = FLA_Obj_buffer_at_view( x );

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   void* A_mat = NULL;
   void* x_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     x_vec = FLA_Obj_buffer_at_view( x );

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -38,6 +38,18 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
+  void* A_mat = NULL;
+  void* x_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    x_vec = FLA_Obj_buffer_at_view( x );
+  }
+  else
+  {
+    A_mat = A_hip;
+    x_vec = x_hip;
+  }
 
   switch( datatype ){
 
@@ -47,8 +59,8 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    blas_trans,
                    blas_diag,
                    m_A,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) x_hip, inc_x );
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) x_vec, inc_x );
 
     break;
   }
@@ -59,8 +71,8 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    blas_trans,
                    blas_diag,
                    m_A,
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) x_hip, inc_x );
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) x_vec, inc_x );
 
     break;
   }
@@ -71,8 +83,8 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    blas_trans,
                    blas_diag,
                    m_A,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) x_hip, inc_x );
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) x_vec, inc_x );
 
     break;
   }
@@ -83,8 +95,8 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    blas_trans,
                    blas_diag,
                    m_A,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) x_hip, inc_x );
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) x_vec, inc_x );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -59,7 +59,7 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -56,6 +56,21 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
   rocblas_operation blas_transa = FLA_Param_map_flame_to_rocblas_trans( transa, FLA_Obj_is_real( A ) );
   rocblas_operation blas_transb = FLA_Param_map_flame_to_rocblas_trans( transb, FLA_Obj_is_real( B ) );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -71,10 +86,10 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
                    n_C,
                    k_AB,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) B_hip, ldim_B,
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) B_mat, ldim_B,
                    buff_beta,
-                   ( float * ) C_hip, ldim_C );
+                   ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -91,10 +106,10 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
                    n_C,
                    k_AB,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) B_hip, ldim_B,
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) B_mat, ldim_B,
                    buff_beta,
-                   ( double * ) C_hip, ldim_C );
+                   ( double * ) C_mat, ldim_C );
     
     break;
   }
@@ -111,10 +126,10 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
                    n_C,
                    k_AB,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_float_complex * ) C_hip, ldim_C );
+                   ( rocblas_float_complex * ) C_mat, ldim_C );
     
     break;
   }
@@ -131,10 +146,10 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
                    n_C,
                    k_AB,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_double_complex * ) C_hip, ldim_C );
+                   ( rocblas_double_complex * ) C_mat, ldim_C );
     
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
@@ -40,7 +40,22 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-  
+
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -55,10 +70,10 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) B_hip, ldim_B,
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) B_mat, ldim_B,
                    buff_beta,
-                   ( float * ) C_hip, ldim_C );
+                   ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -74,10 +89,10 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) B_hip, ldim_B,
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) B_mat, ldim_B,
                    buff_beta,
-                   ( double * ) C_hip, ldim_C );
+                   ( double * ) C_mat, ldim_C );
 
     break;
   }
@@ -93,10 +108,10 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_float_complex * ) C_hip, ldim_C );
+                   ( rocblas_float_complex * ) C_mat, ldim_C );
 
     break;
   }
@@ -112,10 +127,10 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_double_complex * ) C_hip, ldim_C );
+                   ( rocblas_double_complex * ) C_mat, ldim_C );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
@@ -44,7 +44,7 @@ FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -52,7 +52,7 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -49,6 +49,21 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -63,10 +78,10 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( float * ) A_hip, ldim_A,
-                    ( float * ) B_hip, ldim_B,
+                    ( float * ) A_mat, ldim_A,
+                    ( float * ) B_mat, ldim_B,
                     buff_beta,
-                    ( float * ) C_hip, ldim_C );
+                    ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -82,10 +97,10 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( double * ) A_hip, ldim_A,
-                    ( double * ) B_hip, ldim_B,
+                    ( double * ) A_mat, ldim_A,
+                    ( double * ) B_mat, ldim_B,
                     buff_beta,
-                    ( double * ) C_hip, ldim_C );
+                    ( double * ) C_mat, ldim_C );
 
     break;
   }
@@ -101,10 +116,10 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( rocblas_float_complex * ) A_hip, ldim_A,
-                    ( rocblas_float_complex * ) B_hip, ldim_B,
+                    ( rocblas_float_complex * ) A_mat, ldim_A,
+                    ( rocblas_float_complex * ) B_mat, ldim_B,
                     buff_beta,
-                    ( rocblas_float_complex * ) C_hip, ldim_C );
+                    ( rocblas_float_complex * ) C_mat, ldim_C );
 
     break;
   }
@@ -120,10 +135,10 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( rocblas_double_complex * ) A_hip, ldim_A,
-                    ( rocblas_double_complex * ) B_hip, ldim_B,
+                    ( rocblas_double_complex * ) A_mat, ldim_A,
+                    ( rocblas_double_complex * ) B_mat, ldim_B,
                     buff_beta,
-                    ( rocblas_double_complex * ) C_hip, ldim_C );
+                    ( rocblas_double_complex * ) C_mat, ldim_C );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -46,6 +46,18 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
+  void* A_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -60,9 +72,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
+                   ( float * ) A_mat, ldim_A,
                    buff_beta,
-                   ( float * ) C_hip, ldim_C );
+                   ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -78,9 +90,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
+                   ( double * ) A_mat, ldim_A,
                    buff_beta,
-                   ( double * ) C_hip, ldim_C );
+                   ( double * ) C_mat, ldim_C );
 
     break;
   }
@@ -96,9 +108,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
                    buff_beta,
-                   ( rocblas_float_complex * ) C_hip, ldim_C );
+                   ( rocblas_float_complex * ) C_mat, ldim_C );
 
     break;
   }
@@ -114,9 +126,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
                    buff_beta,
-                   ( rocblas_double_complex * ) C_hip, ldim_C );
+                   ( rocblas_double_complex * ) C_mat, ldim_C );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -48,7 +48,7 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   void* A_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     C_mat = FLA_Obj_buffer_at_view( C );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
@@ -44,7 +44,7 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
@@ -41,6 +41,21 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -55,10 +70,10 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) B_hip, ldim_B,
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) B_mat, ldim_B,
                    buff_beta,
-                   ( float * ) C_hip, ldim_C );
+                   ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -74,10 +89,10 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) B_hip, ldim_B,
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) B_mat, ldim_B,
                    buff_beta,
-                   ( double * ) C_hip, ldim_C );
+                   ( double * ) C_mat, ldim_C );
     
     break;
   }
@@ -93,10 +108,10 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) B_hip, ldim_B,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_float_complex * ) C_hip, ldim_C );
+                   ( rocblas_float_complex * ) C_mat, ldim_C );
     
     break;
   }
@@ -112,10 +127,10 @@ FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_C,
                    n_C,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) B_hip, ldim_B,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) B_mat, ldim_B,
                    buff_beta,
-                   ( rocblas_double_complex * ) C_hip, ldim_C );
+                   ( rocblas_double_complex * ) C_mat, ldim_C );
     
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -49,6 +49,21 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -63,10 +78,10 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( float * ) A_hip, ldim_A,
-                    ( float * ) B_hip, ldim_B,
+                    ( float * ) A_mat, ldim_A,
+                    ( float * ) B_mat, ldim_B,
                     buff_beta,
-                    ( float * ) C_hip, ldim_C );
+                    ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -82,10 +97,10 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( double * ) A_hip, ldim_A,
-                    ( double * ) B_hip, ldim_B,
+                    ( double * ) A_mat, ldim_A,
+                    ( double * ) B_mat, ldim_B,
                     buff_beta,
-                    ( double * ) C_hip, ldim_C );
+                    ( double * ) C_mat, ldim_C );
 
     break;
   }
@@ -101,10 +116,10 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( rocblas_float_complex * ) A_hip, ldim_A,
-                    ( rocblas_float_complex * ) B_hip, ldim_B,
+                    ( rocblas_float_complex * ) A_mat, ldim_A,
+                    ( rocblas_float_complex * ) B_mat, ldim_B,
                     buff_beta,
-                    ( rocblas_float_complex * ) C_hip, ldim_C );
+                    ( rocblas_float_complex * ) C_mat, ldim_C );
 
     break;
   }
@@ -120,10 +135,10 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
                     m_C,
                     k_AB,
                     buff_alpha,
-                    ( rocblas_double_complex * ) A_hip, ldim_A,
-                    ( rocblas_double_complex * ) B_hip, ldim_B,
+                    ( rocblas_double_complex * ) A_mat, ldim_A,
+                    ( rocblas_double_complex * ) B_mat, ldim_B,
                     buff_beta,
-                    ( rocblas_double_complex * ) C_hip, ldim_C );
+                    ( rocblas_double_complex * ) C_mat, ldim_C );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -52,7 +52,7 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -46,6 +46,18 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
+  void* A_mat = NULL;
+  void* C_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    C_mat = FLA_Obj_buffer_at_view( C );
+  }
+  else
+  {
+    A_mat = A_hip;
+    C_mat = C_hip;
+  }
 
   switch( datatype ){
 
@@ -60,9 +72,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
+                   ( float * ) A_mat, ldim_A,
                    buff_beta,
-                   ( float * ) C_hip, ldim_C );
+                   ( float * ) C_mat, ldim_C );
     
     break;
   }
@@ -78,9 +90,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
+                   ( double * ) A_mat, ldim_A,
                    buff_beta,
-                   ( double * ) C_hip, ldim_C );
+                   ( double * ) C_mat, ldim_C );
 
     break;
   }
@@ -96,9 +108,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
                    buff_beta,
-                   ( rocblas_float_complex * ) C_hip, ldim_C );
+                   ( rocblas_float_complex * ) C_mat, ldim_C );
 
     break;
   }
@@ -114,9 +126,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
                    m_C,
                    k_A,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
                    buff_beta,
-                   ( rocblas_double_complex * ) C_hip, ldim_C );
+                   ( rocblas_double_complex * ) C_mat, ldim_C );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -48,7 +48,7 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   void* A_mat = NULL;
   void* C_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     C_mat = FLA_Obj_buffer_at_view( C );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -42,7 +42,7 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   void* A_mat = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -40,6 +40,18 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+  }
 
   switch( datatype ){
 
@@ -55,8 +67,8 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) B_hip, ldim_B );
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) B_mat, ldim_B );
     
     break;
   }
@@ -73,8 +85,8 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( double * ) A_hip, ldim_A,
-                   ( double * ) B_hip, ldim_B );
+                   ( double * ) A_mat, ldim_A,
+                   ( double * ) B_mat, ldim_B );
 
     break;
   }
@@ -91,8 +103,8 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) B_hip, ldim_B );
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) B_mat, ldim_B );
 
     break;
   }
@@ -109,8 +121,8 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) B_hip, ldim_B );
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) B_mat, ldim_B );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -40,6 +40,18 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
   rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
+  void* A_mat = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+  }
 
   switch( datatype ){
 
@@ -55,8 +67,8 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( float * ) A_hip, ldim_A,
-                   ( float * ) B_hip, ldim_B );
+                   ( float * ) A_mat, ldim_A,
+                   ( float * ) B_mat, ldim_B );
     
     break;
   }
@@ -73,8 +85,8 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                  m_B,
                  n_B,
                  buff_alpha,
-                 ( double * ) A_hip, ldim_A,
-                 ( double * ) B_hip, ldim_B );
+                 ( double * ) A_mat, ldim_A,
+                 ( double * ) B_mat, ldim_B );
 
     break;
   }
@@ -91,8 +103,8 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( rocblas_float_complex * ) A_hip, ldim_A,
-                   ( rocblas_float_complex * ) B_hip, ldim_B );
+                   ( rocblas_float_complex * ) A_mat, ldim_A,
+                   ( rocblas_float_complex * ) B_mat, ldim_B );
 
     break;
   }
@@ -109,8 +121,8 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
                    m_B,
                    n_B,
                    buff_alpha,
-                   ( rocblas_double_complex * ) A_hip, ldim_A,
-                   ( rocblas_double_complex * ) B_hip, ldim_B );
+                   ( rocblas_double_complex * ) A_mat, ldim_A,
+                   ( rocblas_double_complex * ) B_mat, ldim_B );
 
     break;
   }

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -42,7 +42,7 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   void* A_mat = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     B_mat = FLA_Obj_buffer_at_view( B );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
@@ -47,6 +47,16 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   rocblas_int* info;
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
   switch( datatype ){
 
   case FLA_FLOAT:
@@ -54,7 +64,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_spotrf( handle,
                       blas_uplo,
                       n_A,
-                      ( float * ) A_hip, ldim_A,
+                      ( float * ) A_mat, ldim_A,
                       info );
     
     break;
@@ -65,7 +75,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_dpotrf( handle,
                       blas_uplo,
                       n_A,
-                      ( double * ) A_hip, ldim_A,
+                      ( double * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -76,7 +86,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_cpotrf( handle,
                       blas_uplo,
                       n_A,
-                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      ( rocblas_float_complex * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -87,7 +97,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_zpotrf( handle,
                       blas_uplo,
                       n_A,
-                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      ( rocblas_double_complex * ) A_mat, ldim_A,
                       info );
 
     break;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
@@ -48,7 +48,7 @@ FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
   }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
@@ -47,6 +47,16 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   rocblas_int* info;
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
   switch( datatype ){
 
   case FLA_FLOAT:
@@ -54,7 +64,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_spotf2( handle,
                       blas_uplo,
                       n_A,
-                      ( float * ) A_hip, ldim_A,
+                      ( float * ) A_mat, ldim_A,
                       info );
     
     break;
@@ -65,7 +75,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_dpotf2( handle,
                       blas_uplo,
                       n_A,
-                      ( double * ) A_hip, ldim_A,
+                      ( double * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -76,7 +86,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_cpotf2( handle,
                       blas_uplo,
                       n_A,
-                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      ( rocblas_float_complex * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -87,7 +97,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
     rocsolver_zpotf2( handle,
                       blas_uplo,
                       n_A,
-                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      ( rocblas_double_complex * ) A_mat, ldim_A,
                       info );
 
     break;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
@@ -48,7 +48,7 @@ FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_O
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
   }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
@@ -60,7 +60,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
   }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
@@ -59,6 +59,16 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
   rocblas_int* info;
   hipMalloc( (void**) &info, sizeof( rocblas_int ) );
 
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
   switch( datatype ){
 
   case FLA_FLOAT:
@@ -67,7 +77,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
                       blas_uplo,
                       blas_diag,
                       n_A,
-                      ( float * ) A_hip, ldim_A,
+                      ( float * ) A_mat, ldim_A,
                       info );
     
     break;
@@ -79,7 +89,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
                       blas_uplo,
                       blas_diag,
                       n_A,
-                      ( double * ) A_hip, ldim_A,
+                      ( double * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -91,7 +101,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
                       blas_uplo,
                       blas_diag,
                       n_A,
-                      ( rocblas_float_complex * ) A_hip, ldim_A,
+                      ( rocblas_float_complex * ) A_mat, ldim_A,
                       info );
 
     break;
@@ -103,7 +113,7 @@ FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_
                       blas_uplo,
                       blas_diag,
                       n_A,
-                      ( rocblas_double_complex * ) A_hip, ldim_A,
+                      ( rocblas_double_complex * ) A_mat, ldim_A,
                       info );
 
     break;


### PR DESCRIPTION
Details:
- allow set/get/query of whether managed memory is enabled for HIP
- if enabled, override FLA_buff_malloc/_free to allocate/free managed
  memory for the buffers
- adjust HIP wrappers to switch between directly using the managed memory and
  HIP buffers (thereby continuing to support both paths)
- currently the cache block allocation and management is still done in
  the background