### PR TITLE
External LAPACK functionality through rocSOLVER.

### DIFF
--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -213,6 +213,8 @@ FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hi
 
 FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
 FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
+
+FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -198,22 +198,6 @@ FLA_Error FLA_Svdd_external( FLA_Svd_type jobz, FLA_Obj A, FLA_Obj s, FLA_Obj U,
 
 // --- external HIP prototypes -------------------------------------------------
 #ifdef FLA_ENABLE_HIP
-FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Chol_l_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-
-FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Trinv_lu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Trinv_un_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
-
-FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
-FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
-
 FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
@@ -224,8 +208,16 @@ FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip,
 FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
+FLA_Error FLA_Chol_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_l_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
+FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
+FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
 FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
@@ -242,6 +234,11 @@ FLA_Error FLA_Tridiag_blk_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj
 FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Tridiag_unb_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Trinv_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_lu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_un_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -228,6 +228,8 @@ FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
 FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_LQ_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -214,6 +214,16 @@ FLA_Error FLA_Chol_u_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip 
 FLA_Error FLA_Chol_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Chol_u_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Eig_gest_blk_external_hip( rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_il_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_iu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_nl_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_nu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_unb_external_hip( rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_il_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_iu_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_nl_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Eig_gest_nu_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -226,6 +226,8 @@ FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void
 FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
 FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
+FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -217,6 +217,8 @@ FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* 
 FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
+FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -234,6 +234,8 @@ FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_
 FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_QR_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, void* A_hip, FLA_Obj s, void* s_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
+FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -225,6 +225,7 @@ FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void
 FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
 FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
+FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -222,6 +222,7 @@ FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip,
 FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -237,6 +237,8 @@ FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Sv
 FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Tridiag_blk_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -224,6 +224,7 @@ FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip,
 FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
+FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -239,6 +239,7 @@ FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_O
 FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Tridiag_blk_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -236,6 +236,7 @@ FLA_Error FLA_QR_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA
 FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, void* A_hip, FLA_Obj s, void* s_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
 FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip );
+FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -210,6 +210,9 @@ FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hi
 FLA_Error FLA_Trinv_lu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Trinv_un_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
 FLA_Error FLA_Trinv_uu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip );
+
+FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
+FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -240,6 +240,8 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
 FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Tridiag_blk_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* a_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Tridiag_unb_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -221,6 +221,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
+FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -231,6 +231,8 @@ FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA
 FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_QR_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -216,6 +216,7 @@ FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* 
 
 FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -215,6 +215,7 @@ FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
 
 FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
+FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -233,6 +233,7 @@ FLA_Error FLA_LQ_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA
 FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_QR_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, void* A_hip, FLA_Obj s, void* s_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -230,6 +230,7 @@ FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip
 FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_LQ_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -219,6 +219,8 @@ FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side,
 FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
+FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
+FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_lapack_prototypes.h
+++ b/src/base/flamec/include/FLA_lapack_prototypes.h
@@ -223,6 +223,7 @@ FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip );
 FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
 FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip );
+FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -10,6 +10,7 @@
 
 #ifdef FLA_ENABLE_HIP
 #include <rocblas.h>
+#include <rocsolver.h>
 #endif
 
 // -----------------------------------------------------------------------------
@@ -353,6 +354,7 @@ rocblas_operation FLA_Param_map_flame_to_rocblas_trans( FLA_Trans trans, FLA_Boo
 rocblas_fill      FLA_Param_map_flame_to_rocblas_uplo( FLA_Uplo uplo );
 rocblas_side      FLA_Param_map_flame_to_rocblas_side( FLA_Side side );
 rocblas_diagonal  FLA_Param_map_flame_to_rocblas_diag( FLA_Diag diag );
+rocblas_evect     FLA_Param_map_flame_to_rocblas_evd_type( FLA_Evd_type evd_type );
 #endif
 
 void          FLA_Param_map_flame_to_blis_trans( FLA_Trans trans, trans1_t* blis_trans );

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -355,6 +355,7 @@ rocblas_fill      FLA_Param_map_flame_to_rocblas_uplo( FLA_Uplo uplo );
 rocblas_side      FLA_Param_map_flame_to_rocblas_side( FLA_Side side );
 rocblas_diagonal  FLA_Param_map_flame_to_rocblas_diag( FLA_Diag diag );
 rocblas_evect     FLA_Param_map_flame_to_rocblas_evd_type( FLA_Evd_type evd_type );
+rocblas_svect     FLA_Param_map_flame_to_rocblas_svd_type( FLA_Svd_type svd_type );
 #endif
 
 void          FLA_Param_map_flame_to_blis_trans( FLA_Trans trans, trans1_t* blis_trans );

--- a/src/base/flamec/main/FLA_Param.c
+++ b/src/base/flamec/main/FLA_Param.c
@@ -312,6 +312,33 @@ void FLA_Param_map_flame_to_netlib_svd_type( FLA_Svd_type svd_type, void* lapack
 	}
 }
 
+#ifdef FLA_ENABLE_HIP
+rocblas_svect     FLA_Param_map_flame_to_rocblas_svd_type( FLA_Svd_type svd_type )
+{
+        if      ( svd_type == FLA_SVD_VECTORS_ALL )
+        {
+                return rocblas_svect_all;
+        }
+        else if ( svd_type == FLA_SVD_VECTORS_MIN_COPY )
+        {
+                return rocblas_svect_singular;
+        }
+        else if ( svd_type == FLA_SVD_VECTORS_MIN_OVERWRITE )
+        {
+                return rocblas_svect_overwrite;
+        }
+        else if ( svd_type == FLA_SVD_VECTORS_NONE )
+        {
+                return rocblas_svect_none;
+        }
+        else
+        {
+                FLA_Check_error_code( FLA_INVALID_SVD_TYPE );
+        }
+}
+
+#endif
+
 void FLA_Param_map_flame_to_netlib_machval( FLA_Machval machval, void* blas_machval )
 {
 	if      ( machval == FLA_MACH_EPS )

--- a/src/base/flamec/main/FLA_Param.c
+++ b/src/base/flamec/main/FLA_Param.c
@@ -11,6 +11,7 @@
 #include "FLAME.h"
 #ifdef FLA_ENABLE_HIP
 #include <rocblas.h>
+#include <rocsolver.h>
 #endif
 
 // --- FLAME to BLAS/LAPACK mappings -------------------------------------------
@@ -264,6 +265,28 @@ void FLA_Param_map_flame_to_netlib_evd_type( FLA_Evd_type evd_type, void* lapack
 		FLA_Check_error_code( FLA_INVALID_EVD_TYPE );
 	}
 }
+
+#ifdef FLA_ENABLE_HIP
+rocblas_evect FLA_Param_map_flame_to_rocblas_evd_type( FLA_Evd_type evd_type )
+{
+        if ( evd_type == FLA_EVD_WITHOUT_VECTORS )
+        {
+                return rocblas_evect_none;
+        }
+        else if ( evd_type == FLA_EVD_WITH_VECTORS )
+        {
+                return rocblas_evect_original;
+        }
+        else if ( evd_type == FLA_EVD_OF_TRIDIAG_WITH_VECTORS )
+        {
+                return rocblas_evect_tridiagonal;
+        }
+        else
+        {
+                FLA_Check_error_code( FLA_INVALID_EVD_TYPE );
+        }
+}
+#endif
 
 void FLA_Param_map_flame_to_netlib_svd_type( FLA_Svd_type svd_type, void* lapack_svd_type )
 {

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -335,6 +335,8 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
    typedef FLA_Error(*flash_chol_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
    typedef FLA_Error(*flash_trinv_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip );
    typedef FLA_Error(*flash_eig_gest_hip_p)(rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj Y, void* Y_hip, FLA_Obj B, void* B_hip );
+   typedef FLA_Error(*flash_lu_piv_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
+   typedef FLA_Error(*flash_lu_piv_copy_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
 
    // Level-3 BLAS
    typedef FLA_Error(*flash_gemm_hip_p)(rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip);
@@ -403,6 +405,30 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
                                 output_arg[0],
                                 t->input_arg[0],
                                 input_arg[0] );
+   }
+   // FLA_LU_piv
+   else if ( t->func == (void *) FLA_LU_piv_task )
+   {
+      flash_lu_piv_hip_p func;
+      func = (flash_lu_piv_hip_p) FLA_LU_piv_blk_external_hip;
+
+      func(               handle,
+                          t->output_arg[0],
+                          output_arg[0],
+                          t->fla_arg[0] );
+   }
+   // FLA_LU_piv_copy
+   else if ( t->func == (void *) FLA_LU_piv_copy_task )
+   {
+      flash_lu_piv_copy_hip_p func;
+      func = (flash_lu_piv_copy_hip_p) FLA_LU_piv_copy_external_hip;
+
+      func(               handle,
+                          t->output_arg[0],
+                          output_arg[0],
+                          t->fla_arg[0],
+                          t->output_arg[1],
+                          output_arg[1] );
    }
    // FLA_Gemm
    else if ( t->func == (void *) FLA_Gemm_task )

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -60,7 +60,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LU   ", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           0, 1, 0, 1, \
                           p, A )
 
@@ -69,7 +69,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "LU   ", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           0, 1, 0, 2, \
                           p, A, U )
 

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
@@ -179,7 +179,7 @@ FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FL
                         k_t,
                         buff_A, cs_A,
                         buff_t,
-                       buff_B, cs_B );
+                        buff_B, cs_B );
 
     break;
   }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
@@ -1,0 +1,192 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  // int          m_A, n_A;
+  dim_t        m_B, n_B;
+  dim_t        cs_A;
+  dim_t        cs_B;
+  dim_t        k_t;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Apply_Q_check( side, trans, storev, A, t, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  // m_A      = FLA_Obj_length( A );
+  // n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  cs_B     = FLA_Obj_col_stride( B );
+
+  k_t      = FLA_Obj_vector_dim( t );
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
+
+  void* A_vecs = NULL;
+  void* t_scals = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_vecs = FLA_Obj_buffer_at_view( A );
+    t_scals = FLA_Obj_buffer_at_view( t );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_vecs = A_hip;
+    t_scals = t_hip;
+    B_mat = B_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_vecs;
+    float *buff_t    = ( float * ) t_scals;
+    float *buff_B    = ( float * ) B_mat;
+
+    if ( storev == FLA_COLUMNWISE )
+      rocsolver_sormqr( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+    else // storev == FLA_ROWWISE
+      rocsolver_sormlq( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_vecs;
+    double *buff_t    = ( double * ) t_scals;
+    double *buff_B    = ( double * ) B_mat;
+
+    if ( storev == FLA_COLUMNWISE )
+      rocsolver_dormqr( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+    else // storev == FLA_ROWWISE
+      rocsolver_dormlq( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_vecs;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_scals;
+    rocblas_float_complex *buff_B    = ( rocblas_float_complex * ) B_mat;
+
+    if ( storev == FLA_COLUMNWISE )
+      rocsolver_cunmqr( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+    else // storev == FLA_ROWWISE
+      rocsolver_cunmlq( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_vecs;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_scals;
+    rocblas_double_complex *buff_B    = ( rocblas_double_complex * ) B_mat;
+
+    if ( storev == FLA_COLUMNWISE )
+      rocsolver_zunmqr( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+    else // storev == FLA_ROWWISE
+      rocsolver_zunmlq( handle,
+                        blas_side,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        k_t,
+                        buff_A, cs_A,
+                        buff_t,
+                       buff_B, cs_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
@@ -49,7 +49,7 @@ FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FL
   void* A_vecs = NULL;
   void* t_scals = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_vecs = FLA_Obj_buffer_at_view( A );
     t_scals = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
@@ -1,0 +1,157 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  dim_t        m_B, n_B;
+  dim_t        cs_A;
+  dim_t        cs_B;
+  dim_t        k_t;
+  rocblas_storev blas_vect = rocblas_column_wise;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Apply_Q_check( side, trans, storev, A, t, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  // m_A      = FLA_Obj_length( A );
+  // n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  cs_B     = FLA_Obj_col_stride( B );
+
+  if ( blas_vect == rocblas_column_wise ) k_t = FLA_Obj_vector_dim( t );
+  else                    k_t = FLA_Obj_vector_dim( t ) + 1;
+
+  if ( FLA_Obj_is_real( A ) && trans == FLA_CONJ_TRANSPOSE )
+    trans = FLA_TRANSPOSE;
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
+
+  void* A_vecs = NULL;
+  void* t_scals = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_vecs = FLA_Obj_buffer_at_view( A );
+    t_scals = FLA_Obj_buffer_at_view( t );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_vecs = A_hip;
+    t_scals = t_hip;
+    B_mat = B_hip;
+  }
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_vecs;
+    float *buff_t    = ( float * ) t_scals;
+    float *buff_B    = ( float * ) B_mat;
+
+    rocsolver_sormbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_vecs;
+    double *buff_t    = ( double * ) t_scals;
+    double *buff_B    = ( double * ) B_mat;
+
+    rocsolver_dormbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_vecs;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_scals;
+    rocblas_float_complex *buff_B    = ( rocblas_float_complex * ) B_mat;
+
+    rocsolver_cunmbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_vecs;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_scals;
+    rocblas_double_complex *buff_B    = ( rocblas_double_complex * ) B_mat;
+
+    rocsolver_zunmbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
@@ -53,7 +53,7 @@ FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side,
   void* A_vecs = NULL;
   void* t_scals = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_vecs = FLA_Obj_buffer_at_view( A );
     t_scals = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
@@ -1,0 +1,157 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  dim_t        m_B, n_B;
+  dim_t        cs_A;
+  dim_t        cs_B;
+  dim_t        k_t;
+  rocblas_storev blas_vect = rocblas_row_wise;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Apply_Q_check( side, trans, storev, A, t, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  // m_A      = FLA_Obj_length( A );
+  // n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  cs_B     = FLA_Obj_col_stride( B );
+
+  if ( blas_vect == rocblas_column_wise ) k_t = FLA_Obj_vector_dim( t );
+  else                    k_t = FLA_Obj_vector_dim( t ) + 1;
+
+  if ( FLA_Obj_is_real( A ) && trans == FLA_CONJ_TRANSPOSE )
+    trans = FLA_TRANSPOSE;
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
+
+  void* A_vecs = NULL;
+  void* t_scals = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_vecs = FLA_Obj_buffer_at_view( A );
+    t_scals = FLA_Obj_buffer_at_view( t );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_vecs = A_hip;
+    t_scals = t_hip;
+    B_mat = B_hip;
+  }
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_vecs;
+    float *buff_t    = ( float * ) t_scals;
+    float *buff_B    = ( float * ) B_mat;
+
+    rocsolver_sormbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_vecs;
+    double *buff_t    = ( double * ) t_scals;
+    double *buff_B    = ( double * ) B_mat;
+
+    rocsolver_dormbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_vecs;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_scals;
+    rocblas_float_complex *buff_B    = ( rocblas_float_complex * ) B_mat;
+
+    rocsolver_cunmbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_vecs;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_scals;
+    rocblas_double_complex *buff_B    = ( rocblas_double_complex * ) B_mat;
+
+    rocsolver_zunmbr( handle,
+                      blas_vect,
+                      blas_side,
+                      blas_trans,
+                      m_B,
+                      n_B,
+                      k_t,
+                      buff_A,    cs_A,
+                      buff_t,
+                      buff_B,    cs_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
@@ -53,7 +53,7 @@ FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side,
   void* A_vecs = NULL;
   void* t_scals = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_vecs = FLA_Obj_buffer_at_view( A );
     t_scals = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
@@ -1,0 +1,148 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
+{
+  int          info = 0;
+  FLA_Datatype datatype;
+  int          m_A, n_A, cs_A;
+  int          min_m_n;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Bidiag_check( A, tu, tv );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  min_m_n  = FLA_Obj_min_dim( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* buff_d;
+  void* buff_e;
+  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
+  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
+
+  void* A_mat = NULL;
+  void* tu_scals = NULL;
+  void* tv_scals = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    tu_scals = FLA_Obj_buffer_at_view( tu );
+    tv_scals = FLA_Obj_buffer_at_view( tv );
+  }
+  else
+  {
+    A_mat = A_hip;
+    tu_scals = tu_hip;
+    tv_scals = tv_hip;
+  }
+
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_A    = ( float * ) A_mat;
+    float* buff_tu   = ( float * ) tu_scals;
+    float* buff_tv   = ( float * ) tv_scals;
+
+    rocsolver_sgebrd( handle,
+                      m_A,
+                      n_A,
+                buff_A, &cs_A,
+                buff_d,
+                buff_e,
+                buff_tu,
+                buff_tv );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_A    = ( double * ) A_mat;
+    double* buff_tu   = ( double * ) tu_scals;
+    double* buff_tv   = ( double * ) FLA_DOUBLE_PTR( tv );
+
+    rocsolver_dgebrd( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_tu,
+                      buff_tv );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( A );
+    rocblas_float_complex* buff_tu   = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( tu );
+    rocblas_float_complex* buff_tv   = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( tv );
+
+    rocsolver_cgebrd( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_tu,
+                      buff_tv );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_A    = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( A );
+    rocblas_double_complex* buff_tu   = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( tu );
+    rocblas_double_complex* buff_tv   = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( tv );
+
+    rocsolver_zgebrd( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_tu,
+                      buff_tv );
+
+    break;
+  } 
+
+  }
+
+  hipFree( buff_d );
+  hipFree( buff_e );
+
+  return info;
+}
+
+FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
+{
+  return FLA_Bidiag_blk_external_hip( handle, A, A_hip, tu, tu_hip, tv, tv_hip );
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
@@ -44,7 +44,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
   void* A_mat = NULL;
   void* tu_scals = NULL;
   void* tv_scals = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     tu_scals = FLA_Obj_buffer_at_view( tu );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
@@ -1,0 +1,127 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, k_A;
+  int          cs_A;
+  rocblas_storev blas_vect = rocblas_column_wise;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Bidiag_form_U_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  if ( blas_vect == rocblas_column_wise ) k_A = FLA_Obj_vector_dim( t );
+  else                    k_A = FLA_Obj_vector_dim( t ) + 1;
+
+  void* A_vecs = NULL;
+  void* t_scals = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_vecs = FLA_Obj_buffer_at_view( A );
+    t_scals = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_vecs = A_hip;
+    t_scals = t_hip;
+  }
+
+
+  switch( datatype ){
+
+    case FLA_FLOAT:
+    {
+      float*    buff_A    = ( float    * ) A_vecs;
+      float*    buff_t    = ( float    * ) t_scals;
+
+      rocsolver_sorgbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double*   buff_A    = ( double   * ) A_vecs;
+      double*   buff_t    = ( double   * ) t_scals;
+
+      rocsolver_dorgbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( A );
+      rocblas_float_complex* buff_t    = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( t );
+
+      rocsolver_cungbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( A );
+      rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( t );
+
+      rocsolver_zungbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+  }
+
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void
 
   void* A_vecs = NULL;
   void* t_scals = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_vecs = FLA_Obj_buffer_at_view( A );
     t_scals = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
@@ -1,0 +1,127 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, k_A;
+  int          cs_A;
+  rocblas_storev blas_vect = rocblas_row_wise;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Bidiag_form_V_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  if ( blas_vect == rocblas_column_wise ) k_A = FLA_Obj_vector_dim( t );
+  else                    k_A = FLA_Obj_vector_dim( t ) + 1;
+
+  void* A_vecs = NULL;
+  void* t_scals = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_vecs = FLA_Obj_buffer_at_view( A );
+    t_scals = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_vecs = A_hip;
+    t_scals = t_hip;
+  }
+
+
+  switch( datatype ){
+
+    case FLA_FLOAT:
+    {
+      float*    buff_A    = ( float    * ) A_vecs;
+      float*    buff_t    = ( float    * ) t_scals;
+
+      rocsolver_sorgbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double*   buff_A    = ( double   * ) A_vecs;
+      double*   buff_t    = ( double   * ) t_scals;
+
+      rocsolver_dorgbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( A );
+      rocblas_float_complex* buff_t    = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( t );
+
+      rocsolver_cungbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( A );
+      rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( t );
+
+      rocsolver_zungbr( handle,
+                        blas_vect,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+  }
+
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void
 
   void* A_vecs = NULL;
   void* t_scals = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_vecs = FLA_Obj_buffer_at_view( A );
     t_scals = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
@@ -17,7 +17,7 @@
 #include "rocblas.h"
 #include "rocsolver.h"
 
-FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
+FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
 {
   int          info = 0;
   FLA_Datatype datatype;
@@ -66,7 +66,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
     float* buff_tu   = ( float * ) tu_scals;
     float* buff_tv   = ( float * ) tv_scals;
 
-    rocsolver_sgebrd( handle,
+    rocsolver_sgebd2( handle,
                       m_A,
                       n_A,
                       buff_A, cs_A,
@@ -84,7 +84,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
     double* buff_tu   = ( double * ) tu_scals;
     double* buff_tv   = ( double * ) FLA_DOUBLE_PTR( tv );
 
-    rocsolver_dgebrd( handle,
+    rocsolver_dgebd2( handle,
                       m_A,
                       n_A,
                       buff_A, cs_A,
@@ -102,7 +102,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
     rocblas_float_complex* buff_tu   = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( tu );
     rocblas_float_complex* buff_tv   = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( tv );
 
-    rocsolver_cgebrd( handle,
+    rocsolver_cgebd2( handle,
                       m_A,
                       n_A,
                       buff_A, cs_A,
@@ -120,7 +120,7 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
     rocblas_double_complex* buff_tu   = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( tu );
     rocblas_double_complex* buff_tv   = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( tv );
 
-    rocsolver_zgebrd( handle,
+    rocsolver_zgebd2( handle,
                       m_A,
                       n_A,
                       buff_A, cs_A,
@@ -140,9 +140,9 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
   return info;
 }
 
-FLA_Error FLA_Bidiag_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
+FLA_Error FLA_Bidiag_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
 {
-  return FLA_Bidiag_blk_external_hip( handle, A, A_hip, tu, tu_hip, tv, tv_hip );
+  return FLA_Bidiag_unb_external_hip( handle, A, A_hip, tu, tu_hip, tv, tv_hip );
 }
 
 #endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
@@ -44,7 +44,7 @@ FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A
   void* A_mat = NULL;
   void* tu_scals = NULL;
   void* tv_scals = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     tu_scals = FLA_Obj_buffer_at_view( tu );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
@@ -1,0 +1,177 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip )
+{
+  FLA_Datatype datatype;
+  int          m_U, cs_U;
+  int          n_V, cs_V;
+  int          n_C, cs_C;
+  int          min_m_n;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Hevd_check( jobz, uplo, A, e );
+
+  if ( FLA_Obj_has_zero_dim( d ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( U );
+
+  m_U      = FLA_Obj_length( U );
+  cs_U     = FLA_Obj_col_stride( U );
+
+  n_V      = FLA_Obj_length( V );
+  cs_V     = FLA_Obj_col_stride( V );
+
+  n_C      = 0;
+  cs_C     = 1;
+
+  min_m_n  = FLA_Obj_vector_dim( d );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* d_vec = NULL;
+  void* e_vec = NULL;
+  void* U_mat = NULL;
+  void* V_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    d_vec = FLA_Obj_buffer_at_view( d );
+    e_vec = FLA_Obj_buffer_at_view( e );
+    U_mat = FLA_Obj_buffer_at_view( U );
+    V_mat = FLA_Obj_buffer_at_view( V );
+  }
+  else
+  {
+    d_vec = d_hip;
+    e_vec = e_hip;
+    U_mat = U_hip;
+    V_mat = V_hip;
+  }
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float*    buff_d     = ( float * ) d_vec;
+      float*    buff_e     = ( float * ) e_vec;
+      float*    buff_U     = ( float * ) U_mat;
+      float*    buff_V     = ( float * ) V_mat;
+      float*    buff_C     = ( float * ) NULL;
+  
+      rocsolver_sbdsqr( handle,
+                        blas_uplo,
+                        min_m_n,
+                        n_V,
+                        m_U,
+                        n_C,
+                        buff_d,
+                        buff_e,
+                        buff_V, cs_V,
+                        buff_U, cs_U,
+                        buff_C, cs_C,
+                        info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double*   buff_d     = ( double * ) FLA_DOUBLE_PTR( d );
+      double*   buff_e     = ( double * ) FLA_DOUBLE_PTR( e );
+      double*   buff_U     = ( double * ) FLA_DOUBLE_PTR( U );
+      double*   buff_V     = ( double * ) FLA_DOUBLE_PTR( V );
+      double*   buff_C     = ( double * ) NULL;
+  
+      rocsolver_dbdsqr( handle,
+                        blas_uplo,
+                        min_m_n,
+                        n_V,
+                        m_U,
+                        n_C,
+                        buff_d,
+                        buff_e,
+                        buff_V, cs_V,
+                        buff_U, cs_U,
+                        buff_C, cs_C,
+                        info );
+
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      float*    buff_d     = ( float    * ) FLA_FLOAT_PTR( d );
+      float*    buff_e     = ( float    * ) FLA_FLOAT_PTR( e );
+      rocblas_float_complex* buff_U     = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( U );
+      rocblas_float_complex* buff_V     = ( rocblas_float_complex * ) FLA_COMPLEX_PTR( V );
+      rocblas_float_complex* buff_C     = ( rocblas_float_complex * ) NULL;
+  
+      rocsolver_cbdsqr( handle,
+                        blas_uplo,
+                        min_m_n,
+                        n_V,
+                        m_U,
+                        n_C,
+                        buff_d,
+                        buff_e,
+                        buff_V, cs_V,
+                        buff_U, cs_U,
+                        buff_C, cs_C,
+                        info );
+
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      double*   buff_d     = ( double   * ) FLA_DOUBLE_PTR( d );
+      double*   buff_e     = ( double   * ) FLA_DOUBLE_PTR( e );
+      rocblas_double_complex* buff_U     = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( U );
+      rocblas_double_complex* buff_V     = ( rocblas_double_complex * ) FLA_DOUBLE_COMPLEX_PTR( V );
+      rocblas_double_complex* buff_C     = ( rocblas_double_complex * ) NULL;
+  
+      rocsolver_zbdsqr( handle,
+                        blas_uplo,
+                        min_m_n,
+                        n_V,
+                        m_U,
+                        n_C,
+                        buff_d,
+                        buff_e,
+                        buff_V, cs_V,
+                        buff_U, cs_U,
+                        buff_C, cs_C,
+                        info );
+
+      break;
+    } 
+
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree(info);
+
+  return rval;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
@@ -49,7 +49,7 @@ FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d
   void* e_vec = NULL;
   void* U_mat = NULL;
   void* V_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     d_vec = FLA_Obj_buffer_at_view( d );
     e_vec = FLA_Obj_buffer_at_view( e );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_blk_external_hip.c
@@ -1,0 +1,132 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+
+FLA_Error FLA_Eig_gest_il_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_blk_external_hip( handle, FLA_INVERSE, FLA_LOWER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_iu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_blk_external_hip( handle, FLA_INVERSE, FLA_UPPER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_nl_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_blk_external_hip( handle, FLA_NO_INVERSE, FLA_LOWER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_nu_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_blk_external_hip( handle, FLA_NO_INVERSE, FLA_UPPER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_blk_external_hip( rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  rocblas_eform  itype;
+  FLA_Datatype datatype;
+  int          n_A, ld_A;
+  int          ld_B;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Eig_gest_check( inv, uplo, A, B );
+
+//  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+  if ( inv == FLA_INVERSE )
+    itype  = rocblas_eform_ax;
+  else
+    itype  = rocblas_eform_abx;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  ld_A     = FLA_Obj_col_stride( A );
+  ld_B     = FLA_Obj_col_stride( B );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* A_buff = NULL;
+  void* B_buff = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
+  {
+    A_buff = FLA_Obj_buffer_at_view( A );
+    B_buff = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_buff = A_hip;
+    B_buff = B_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+
+    rocsolver_ssygst( handle, itype,
+                blas_uplo,
+                n_A,
+                ( float * ) A_buff, ld_A,
+                ( float * ) B_buff, ld_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+
+    rocsolver_dsygst( handle, itype,
+                blas_uplo,
+                n_A,
+                ( double * ) A_buff, ld_A,
+                ( double * ) B_buff, ld_B );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+
+    rocsolver_chegst( handle, itype,
+                blas_uplo,
+                n_A,
+                ( rocblas_float_complex * ) A_buff, ld_A,
+                ( rocblas_float_complex * ) B_buff, ld_B );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+
+    rocsolver_zhegst( handle, itype,
+                blas_uplo,
+                n_A,
+                ( rocblas_double_complex * ) A_buff, ld_A,
+                ( rocblas_double_complex * ) B_buff, ld_B );
+
+    break;
+  } 
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_unb_external_hip.c
@@ -1,0 +1,133 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Eig_gest_il_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_unb_external_hip( handle, FLA_INVERSE, FLA_LOWER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_iu_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_unb_external_hip( handle, FLA_INVERSE, FLA_UPPER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_nl_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_unb_external_hip( handle, FLA_NO_INVERSE, FLA_LOWER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_nu_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  return FLA_Eig_gest_unb_external_hip( handle, FLA_NO_INVERSE, FLA_UPPER_TRIANGULAR, A, A_hip, B, B_hip );
+}
+
+FLA_Error FLA_Eig_gest_unb_external_hip( rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  rocblas_eform  itype;
+  FLA_Datatype datatype;
+  int          n_A, ld_A;
+  int          ld_B;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Eig_gest_check( inv, uplo, A, B );
+
+//  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+  if ( inv == FLA_INVERSE )
+    itype  = rocblas_eform_ax;
+  else
+    itype  = rocblas_eform_abx;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  ld_A     = FLA_Obj_col_stride( A );
+  ld_B     = FLA_Obj_col_stride( B );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* A_buff = NULL;
+  void* B_buff = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_buff = FLA_Obj_buffer_at_view( A );
+    B_buff = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_buff = A_hip;
+    B_buff = B_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+
+    rocsolver_ssygs2( handle, itype,
+                blas_uplo,
+                n_A,
+                ( float * ) A_buff, ld_A,
+                ( float * ) B_buff, ld_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+
+    rocsolver_dsygs2( handle, itype,
+                blas_uplo,
+                n_A,
+                ( double * ) A_buff, ld_A,
+                ( double * ) B_buff, ld_B );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+
+    rocsolver_chegs2( handle, itype,
+                blas_uplo,
+                n_A,
+                ( rocblas_float_complex * ) A_buff, ld_A,
+                ( rocblas_float_complex * ) B_buff, ld_B );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+
+    rocsolver_zhegs2( handle, itype,
+                blas_uplo,
+                n_A,
+                ( rocblas_double_complex * ) A_buff, ld_A,
+                ( rocblas_double_complex * ) B_buff, ld_B );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif
+
+

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
@@ -1,0 +1,123 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Hevdd_check( jobz, uplo, A, e );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  rocblas_evect blas_jobz = FLA_Param_map_flame_to_rocblas_evd_type( jobz );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+  void* buff_work;
+  hipMalloc( &buff_work, n_A * FLA_Obj_datatype_size ( FLA_Obj_datatype( A ) ) );
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float* buff_A     = ( float* ) FLA_FLOAT_PTR( A );
+      float* buff_e     = ( float* ) FLA_FLOAT_PTR( e );
+
+      rocsolver_ssyev( handle,
+                       blas_jobz,
+                       blas_uplo,
+                       n_A,
+                       buff_A,     cs_A,
+                       buff_e,
+                       buff_work,
+                       info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double* buff_A     = ( double* ) FLA_DOUBLE_PTR( A );
+      double* buff_e     = ( double* ) FLA_DOUBLE_PTR( e );
+  
+      rocsolver_dsyev( handle,
+                       blas_jobz,
+                       blas_uplo,
+                       n_A,
+                       buff_A,     cs_A,
+                       buff_e,
+                       buff_work,
+                       info );
+  
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( A );
+      float*    buff_e     = ( float*    ) FLA_FLOAT_PTR( e );
+  
+      rocsolver_cheev( handle,
+                       blas_jobz,
+                       blas_uplo,
+                       n_A,
+                       buff_A,     cs_A,
+                       buff_e,
+                       buff_work,
+                       info );
+  
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( A );
+      double*   buff_e     = ( double*   ) FLA_DOUBLE_PTR( e );
+  
+      rocsolver_zheev( handle,
+                       blas_jobz,
+                       blas_uplo,
+                       n_A,
+                       buff_A,     cs_A,
+                       buff_e,
+                       buff_work,
+                       info );
+  
+      break;
+    } 
+
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree( info );
+  hipFree( buff_work );
+
+  return rval;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
@@ -40,12 +40,25 @@ FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_U
   void* buff_work;
   hipMalloc( &buff_work, n_A * FLA_Obj_datatype_size ( FLA_Obj_datatype( A ) ) );
 
+  void* A_mat = NULL;
+  void* e_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    e_vec = FLA_Obj_buffer_at_view( e );
+  }
+  else
+  {
+    A_mat = A_hip;
+    e_vec = e_hip;
+  }
+
   switch( datatype ) {
 
     case FLA_FLOAT:
     {
-      float* buff_A     = ( float* ) FLA_FLOAT_PTR( A );
-      float* buff_e     = ( float* ) FLA_FLOAT_PTR( e );
+      float* buff_A     = ( float* ) A_mat;
+      float* buff_e     = ( float* ) e_vec;
 
       rocsolver_ssyev( handle,
                        blas_jobz,
@@ -61,8 +74,8 @@ FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_U
 
     case FLA_DOUBLE:
     {
-      double* buff_A     = ( double* ) FLA_DOUBLE_PTR( A );
-      double* buff_e     = ( double* ) FLA_DOUBLE_PTR( e );
+      double* buff_A     = ( double* ) A_mat;
+      double* buff_e     = ( double* ) e_vec;
   
       rocsolver_dsyev( handle,
                        blas_jobz,
@@ -78,8 +91,8 @@ FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_U
   
     case FLA_COMPLEX:
     {
-      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( A );
-      float*    buff_e     = ( float*    ) FLA_FLOAT_PTR( e );
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) A_mat;
+      float*    buff_e     = ( float*    ) e_vec;
   
       rocsolver_cheev( handle,
                        blas_jobz,
@@ -95,8 +108,8 @@ FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_U
   
     case FLA_DOUBLE_COMPLEX:
     {
-      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( A );
-      double*   buff_e     = ( double*   ) FLA_DOUBLE_PTR( e );
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) A_mat;
+      double*   buff_e     = ( double*   ) e_vec;
   
       rocsolver_zheev( handle,
                        blas_jobz,

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
@@ -1,0 +1,123 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Hevdd_check( jobz, uplo, A, e );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  rocblas_evect blas_jobz = FLA_Param_map_flame_to_rocblas_evd_type( jobz );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+  void* buff_work;
+  hipMalloc( &buff_work, n_A * FLA_Obj_datatype_size ( FLA_Obj_datatype( A ) ) );
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float* buff_A     = ( float* ) FLA_FLOAT_PTR( A );
+      float* buff_e     = ( float* ) FLA_FLOAT_PTR( e );
+
+      rocsolver_ssyevd( handle,
+                        blas_jobz,
+                        blas_uplo,
+                        n_A,
+                        buff_A,     cs_A,
+                        buff_e,
+                        buff_work,
+                        info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double* buff_A     = ( double* ) FLA_DOUBLE_PTR( A );
+      double* buff_e     = ( double* ) FLA_DOUBLE_PTR( e );
+  
+      rocsolver_dsyevd( handle,
+                        blas_jobz,
+                        blas_uplo,
+                        n_A,
+                        buff_A,     cs_A,
+                        buff_e,
+                        buff_work,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( A );
+      float*    buff_e     = ( float*    ) FLA_FLOAT_PTR( e );
+  
+      rocsolver_cheevd( handle,
+                        blas_jobz,
+                        blas_uplo,
+                        n_A,
+                        buff_A,     cs_A,
+                        buff_e,
+                        buff_work,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( A );
+      double*   buff_e     = ( double*   ) FLA_DOUBLE_PTR( e );
+  
+      rocsolver_zheevd( handle,
+                        blas_jobz,
+                        blas_uplo,
+                        n_A,
+                        buff_A,     cs_A,
+                        buff_e,
+                        buff_work,
+                        info );
+  
+      break;
+    } 
+
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree( info );
+  hipFree( buff_work );
+
+  return rval;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
@@ -40,12 +40,25 @@ FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
   void* buff_work;
   hipMalloc( &buff_work, n_A * FLA_Obj_datatype_size ( FLA_Obj_datatype( A ) ) );
 
+  void* A_mat = NULL;
+  void* e_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    e_vec = FLA_Obj_buffer_at_view( e );
+  }
+  else
+  {
+    A_mat = A_hip;
+    e_vec = e_hip;
+  }
+
   switch( datatype ) {
 
     case FLA_FLOAT:
     {
-      float* buff_A     = ( float* ) FLA_FLOAT_PTR( A );
-      float* buff_e     = ( float* ) FLA_FLOAT_PTR( e );
+      float* buff_A     = ( float* ) A_mat;
+      float* buff_e     = ( float* ) e_vec;
 
       rocsolver_ssyevd( handle,
                         blas_jobz,
@@ -61,8 +74,8 @@ FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
 
     case FLA_DOUBLE:
     {
-      double* buff_A     = ( double* ) FLA_DOUBLE_PTR( A );
-      double* buff_e     = ( double* ) FLA_DOUBLE_PTR( e );
+      double* buff_A     = ( double* ) A_mat;
+      double* buff_e     = ( double* ) e_vec;
   
       rocsolver_dsyevd( handle,
                         blas_jobz,
@@ -78,8 +91,8 @@ FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
   
     case FLA_COMPLEX:
     {
-      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) FLA_COMPLEX_PTR( A );
-      float*    buff_e     = ( float*    ) FLA_FLOAT_PTR( e );
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) A_mat;
+      float*    buff_e     = ( float*    ) e_vec;
   
       rocsolver_cheevd( handle,
                         blas_jobz,
@@ -95,8 +108,8 @@ FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
   
     case FLA_DOUBLE_COMPLEX:
     {
-      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) FLA_DOUBLE_COMPLEX_PTR( A );
-      double*   buff_e     = ( double*   ) FLA_DOUBLE_PTR( e );
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) A_mat;
+      double*   buff_e     = ( double*   ) e_vec;
   
       rocsolver_zheevd( handle,
                         blas_jobz,

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
@@ -1,0 +1,117 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_LQ_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_mat;
+    float *buff_t    = ( float * ) t_vec;
+
+    rocsolver_sgelqf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_mat;
+    double *buff_t    = ( double * ) t_vec;
+
+    rocsolver_dgelqf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_mat;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_vec;
+
+    rocsolver_cgelqf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+
+    rocsolver_zgelqf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+FLA_Error FLA_LQ_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  return FLA_LQ_blk_external_hip( handle, A, A_hip, t, t_hip );
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
@@ -1,0 +1,117 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_LQ_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_mat;
+    float *buff_t    = ( float * ) t_vec;
+
+    rocsolver_sgelq2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_mat;
+    double *buff_t    = ( double * ) t_vec;
+
+    rocsolver_dgelq2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_mat;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_vec;
+
+    rocsolver_cgelq2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+
+    rocsolver_zgelq2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+FLA_Error FLA_LQ_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  return FLA_LQ_unb_external_hip( handle, A, A_hip, t, t_hip );
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
@@ -39,7 +39,7 @@ FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 
   void* A_mat;
   void* p_vec;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     p_vec = FLA_Obj_buffer_at_view( p );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
@@ -1,0 +1,141 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p )
+{
+  FLA_Error    r_val = FLA_SUCCESS;
+  FLA_Datatype datatype;
+  dim_t        m_A, n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_LU_piv_check( A, p );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  rocblas_int* info;
+  hipMallocManaged( (void**) &info, sizeof( rocblas_int ), hipMemAttachGlobal );
+
+  void* A_mat;
+  void* p_vec;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    p_vec = FLA_Obj_buffer_at_view( p );
+  }
+  else
+  {
+    A_mat = A_hip;
+    p_vec = FLA_Obj_buffer_at_view( p ); // it's host malloc'd, so slow but usable
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A = ( float * ) A_mat;
+    int   *buff_p = ( int   * ) p_vec;
+
+    rocsolver_sgetrf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_p,
+                      info );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A = ( double * ) A_mat;
+    int    *buff_p = ( int    * ) p_vec;
+
+    rocsolver_dgetrf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_p,
+                      info );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A = ( rocblas_float_complex * ) A_mat;
+    int      *buff_p = ( int      * ) p_vec;
+
+    rocsolver_cgetrf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_p,
+                      info );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A = ( rocblas_double_complex * ) A_mat;
+    int      *buff_p = ( int      * ) p_vec;
+
+    rocsolver_zgetrf( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_p,
+                      info );
+
+    break;
+  } 
+
+  }
+
+  // synchronization here is needed b/c of using the pivot data
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  hipError_t err = hipStreamSynchronize( stream );
+  if ( err != hipSuccess )
+  {
+    fprintf( stderr,
+             "Failure to synchronize on HIP stream in LU. err=%d\n",
+             err );
+    return FLA_FAILURE;
+  }
+
+  // XXX HIP kernel
+  FLA_Shift_pivots_to( FLA_NATIVE_PIVOTS, p );
+
+  // Convert to zero-based indexing, if an index was reported.
+  if ( info > 0 ) r_val = *info - 1;
+  else            r_val = FLA_SUCCESS;
+
+  hipFree( info );
+
+  return r_val;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_copy_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_copy_external_hip.c
@@ -1,0 +1,35 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip )
+{
+  FLA_Error r_val;
+
+  r_val = FLA_LU_piv_blk_external_hip( handle, A, A_hip, p );
+  if ( r_val != FLA_SUCCESS )
+  {
+    return r_val;
+  }
+
+  r_val = FLA_Copy_external_hip( handle, A, A_hip, U, U_hip );
+
+  return r_val;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
@@ -1,0 +1,120 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, k_A;
+  int          cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_QR_form_Q_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  k_A      = FLA_Obj_vector_dim( t );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+    case FLA_FLOAT:
+    {
+      float*    buff_A    = ( float    * ) A_mat;
+      float*    buff_t    = ( float    * ) t_vec;
+
+      rocsolver_sorgqr( handle,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double*   buff_A    = ( double   * ) A_mat;
+      double*   buff_t    = ( double   * ) t_vec;
+
+      rocsolver_dorgqr( handle,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) A_mat;
+      rocblas_float_complex* buff_t    = ( rocblas_float_complex * ) t_vec;
+
+      rocsolver_cungqr( handle,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+      rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+
+      rocsolver_zungqr( handle,
+                        m_A,
+                        n_A,
+                        k_A,
+                        buff_A, cs_A,
+                        buff_t );
+
+      break;
+    }
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif
+

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
@@ -38,7 +38,7 @@ FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
@@ -1,0 +1,117 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A, n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_QR_check( A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float *buff_A    = ( float * ) A_mat;
+    float *buff_t    = ( float * ) t_vec;
+
+    rocsolver_sgeqr2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double *buff_A    = ( double * ) A_mat;
+    double *buff_t    = ( double * ) t_vec;
+
+    rocsolver_dgeqr2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_mat;
+    rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_vec;
+
+    rocsolver_cgeqr2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+
+    rocsolver_zgeqr2( handle,
+                      m_A,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  } 
+
+  }
+
+  return FLA_SUCCESS;
+}
+
+FLA_Error FLA_QR_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  return FLA_QR_unb_external_hip( handle, A, A_hip, t, t_hip );
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
@@ -35,7 +35,7 @@ FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
@@ -1,0 +1,178 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, void* A_hip, FLA_Obj s, void* s_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip )
+{
+  FLA_Datatype datatype;
+  FLA_Datatype dt_real;
+  int          m_A, n_A, cs_A;
+  int          cs_U;
+  int          cs_V;
+  int          min_m_n;
+  rocblas_workmode fast_alg = rocblas_outofplace;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Svd_check( jobu, jobv, A, s, U, V );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+  dt_real  = FLA_Obj_datatype_proj_to_real( A );
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  cs_U     = FLA_Obj_col_stride( U );
+
+  cs_V     = FLA_Obj_col_stride( V );
+
+  min_m_n  = min( m_A, n_A );
+
+  rocblas_svect blas_jobu = FLA_Param_map_flame_to_rocblas_svd_type( jobu );
+  rocblas_svect blas_jobv = FLA_Param_map_flame_to_rocblas_svd_type( jobv );
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+  void* buff_work;
+  hipMalloc( &buff_work, FLA_Obj_datatype_size ( dt_real ) * min_m_n );
+
+  void* A_mat = NULL;
+  void* s_vec = NULL;
+  void* U_mat = NULL;
+  void* V_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    s_vec = FLA_Obj_buffer_at_view( s );
+    U_mat = FLA_Obj_buffer_at_view( U );
+    V_mat = FLA_Obj_buffer_at_view( V );
+  }
+  else
+  {
+    A_mat = A_hip;
+    s_vec = s_hip;
+    U_mat = U_hip;
+    V_mat = V_hip;
+  }
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float*    buff_A     = ( float*    ) A_mat;
+      float*    buff_s     = ( float*    ) s_vec;
+      float*    buff_U     = ( float*    ) U_mat;
+      float*    buff_V     = ( float*    ) V_mat;
+  
+      rocsolver_sgesvd( handle,
+                        blas_jobu,
+                        blas_jobv,
+                        m_A,
+                        n_A,
+                        buff_A,    cs_A,
+                        buff_s,
+                        buff_U,    cs_U,
+                        buff_V,    cs_V,
+                        buff_work,
+                        fast_alg,
+                        info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double*   buff_A     = ( double*   ) A_mat;
+      double*   buff_s     = ( double*   ) s_vec;
+      double*   buff_U     = ( double*   ) U_mat;
+      double*   buff_V     = ( double*   ) V_mat;
+  
+      rocsolver_dgesvd( handle,
+                        blas_jobu,
+                        blas_jobv,
+                        m_A,
+                        n_A,
+                        buff_A,    cs_A,
+                        buff_s,
+                        buff_U,    cs_U,
+                        buff_V,    cs_V,
+                        buff_work,
+                        fast_alg,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) A_mat;
+      float*    buff_s     = ( float*    ) s_vec;
+      rocblas_float_complex* buff_U     = ( rocblas_float_complex* ) U_mat;
+      rocblas_float_complex* buff_V     = ( rocblas_float_complex* ) V_mat;
+  
+      rocsolver_cgesvd( handle,
+                        blas_jobu,
+                        blas_jobv,
+                        m_A,
+                        n_A,
+                        buff_A,    cs_A,
+                        buff_s,
+                        buff_U,    cs_U,
+                        buff_V,    cs_V,
+                        buff_work,
+                        fast_alg,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) A_mat;
+      double*   buff_s     = ( double*   ) s_vec;
+      rocblas_double_complex* buff_U     = ( rocblas_double_complex* ) U_mat;
+      rocblas_double_complex* buff_V     = ( rocblas_double_complex* ) V_mat;
+  
+      rocsolver_zgesvd( handle,
+                        blas_jobu,
+                        blas_jobv,
+                        m_A,
+                        n_A,
+                        buff_A,    cs_A,
+                        buff_s,
+                        buff_U,    cs_U,
+                        buff_V,    cs_V,
+                        buff_work,
+                        fast_alg,
+                        info );
+  
+      break;
+    } 
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree( info );
+  hipFree( buff_work );
+
+  return rval;
+}
+#endif
+

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
@@ -57,7 +57,7 @@ FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Sv
   void* s_vec = NULL;
   void* U_mat = NULL;
   void* V_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     s_vec = FLA_Obj_buffer_at_view( s );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
@@ -1,0 +1,140 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Tevdd_check( jobz, d, e, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  if ( FLA_Obj_vector_inc( d ) != 1 )
+  {
+    fprintf( stderr, "FLA_Tevd_external_hip does not support a vector increment != 1. Is:%ld.\n", FLA_Obj_vector_inc( d ) );
+    return FLA_FAILURE;
+  }
+
+  rocblas_evect blas_jobz = FLA_Param_map_flame_to_rocblas_evd_type( jobz );
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  void* d_vec = NULL;
+  void* e_vec = NULL;
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    d_vec = FLA_Obj_buffer_at_view( d );
+    e_vec = FLA_Obj_buffer_at_view( e );
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    d_vec = d_hip;
+    e_vec = e_hip;
+    A_mat = A_hip;
+  }
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float* buff_d     = ( float* ) d_vec;
+      float* buff_e     = ( float* ) e_vec;
+      float* buff_A     = ( float* ) A_mat;
+
+      rocsolver_ssteqr( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double* buff_d     = ( double* ) d_vec;
+      double* buff_e     = ( double* ) e_vec;
+      double* buff_A     = ( double* ) A_mat;
+  
+      rocsolver_dsteqr( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      float*    buff_d     = ( float*    ) d_vec;
+      float*    buff_e     = ( float*    ) e_vec;
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) A_mat;
+  
+      rocsolver_csteqr( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      double*   buff_d     = ( double*   ) d_vec;
+      double*   buff_e     = ( double*   ) e_vec;
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) A_mat;
+  
+      rocsolver_zsteqr( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree( info );
+
+  return rval;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
@@ -46,7 +46,7 @@ FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_O
   void* d_vec = NULL;
   void* e_vec = NULL;
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     d_vec = FLA_Obj_buffer_at_view( d );
     e_vec = FLA_Obj_buffer_at_view( e );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
@@ -1,0 +1,134 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Tevdd_check( jobz, d, e, A );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  rocblas_evect blas_jobz = FLA_Param_map_flame_to_rocblas_evd_type( jobz );
+
+  rocblas_int* info;
+  hipMalloc( (void**) &info, sizeof( rocblas_int ) );
+
+  void* d_vec = NULL;
+  void* e_vec = NULL;
+  void* A_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    d_vec = FLA_Obj_buffer_at_view( d );
+    e_vec = FLA_Obj_buffer_at_view( e );
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    d_vec = d_hip;
+    e_vec = e_hip;
+    A_mat = A_hip;
+  }
+
+  switch( datatype ) {
+
+    case FLA_FLOAT:
+    {
+      float* buff_d     = ( float* ) d_vec;
+      float* buff_e     = ( float* ) e_vec;
+      float* buff_A     = ( float* ) A_mat;
+
+      rocsolver_sstedc( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+
+      break;
+    }
+
+    case FLA_DOUBLE:
+    {
+      double* buff_d     = ( double* ) d_vec;
+      double* buff_e     = ( double* ) e_vec;
+      double* buff_A     = ( double* ) A_mat;
+  
+      rocsolver_dstedc( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_COMPLEX:
+    {
+      float*    buff_d     = ( float*    ) d_vec;
+      float*    buff_e     = ( float*    ) e_vec;
+      rocblas_float_complex* buff_A     = ( rocblas_float_complex* ) A_mat;
+  
+      rocsolver_cstedc( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      double*   buff_d     = ( double*   ) d_vec;
+      double*   buff_e     = ( double*   ) e_vec;
+      rocblas_double_complex* buff_A     = ( rocblas_double_complex* ) A_mat;
+  
+      rocsolver_zstedc( handle,
+                        blas_jobz,
+                        n_A,
+                        buff_d,
+                        buff_e,
+                        buff_A,     cs_A,
+                        info );
+  
+      break;
+    } 
+  }
+
+  int rval = ( info == hipSuccess ) ? FLA_SUCCESS : FLA_FAILURE;
+
+  hipFree( info );
+
+  return rval;
+}
+
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
@@ -40,7 +40,7 @@ FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_
   void* d_vec = NULL;
   void* e_vec = NULL;
   void* A_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     d_vec = FLA_Obj_buffer_at_view( d );
     e_vec = FLA_Obj_buffer_at_view( e );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
@@ -1,0 +1,144 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
+{
+  FLA_Datatype datatype;
+  // int          m_A, n_A;
+  int          m_B, n_B;
+  int          cs_A;
+  int          cs_B;
+
+  //if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+  //  FLA_Apply_Q_check( side, trans, storev, A, t, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  // m_A      = FLA_Obj_length( A );
+  // n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  m_B      = FLA_Obj_length( B );
+  n_B      = FLA_Obj_width( B );
+  cs_B     = FLA_Obj_col_stride( B );
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  void* B_mat = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+    B_mat = B_hip;
+  }
+
+  switch( datatype ){
+  
+    case FLA_FLOAT:
+    {
+      float *buff_A    = ( float * ) A_mat;
+      float *buff_t    = ( float * ) t_vec;
+      float *buff_B    = ( float * ) B_mat;
+  
+      rocsolver_sormtr( handle,
+                        blas_side,
+                        blas_uplo,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+  
+      break;
+    }
+  
+    case FLA_DOUBLE:
+    {
+      double *buff_A    = ( double * ) A_mat;
+      double *buff_t    = ( double * ) t_vec;
+      double *buff_B    = ( double * ) B_mat;
+  
+      rocsolver_dormtr( handle,
+                        blas_side,
+                        blas_uplo,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+  
+      break;
+    }
+  
+    case FLA_COMPLEX:
+    {
+      rocblas_float_complex *buff_A    = ( rocblas_float_complex * ) A_mat;
+      rocblas_float_complex *buff_t    = ( rocblas_float_complex * ) t_vec;
+      rocblas_float_complex *buff_B    = ( rocblas_float_complex * ) B_mat;
+  
+      rocsolver_cunmtr( handle,
+                        blas_side,
+                        blas_uplo,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+  
+      break;
+    }
+  
+    case FLA_DOUBLE_COMPLEX:
+    {
+      rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+      rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+      rocblas_double_complex *buff_B    = ( rocblas_double_complex * ) B_mat;
+  
+      rocsolver_zunmtr( handle,
+                        blas_side,
+                        blas_uplo,
+                        blas_trans,
+                        m_B,
+                        n_B,
+                        buff_A, cs_A,
+                        buff_t,
+                        buff_B, cs_B );
+  
+      break;
+    }
+  }
+
+  return FLA_SUCCESS;
+}
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
@@ -47,7 +47,7 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
   void* A_mat = NULL;
   void* t_vec = NULL;
   void* B_mat = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
@@ -1,0 +1,133 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Tridiag_check( uplo, A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* buff_d;
+  void* buff_e;
+  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A );
+  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ) );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_A    = ( float * ) A_mat;
+    float* buff_t    = ( float * ) t_vec;
+
+    rocsolver_ssytrd( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_A    = ( double * ) A_mat;
+    double* buff_t    = ( double * ) t_vec;
+
+    rocsolver_dsytrd( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) A_mat;
+    rocblas_float_complex* buff_t    = ( rocblas_float_complex * ) t_vec;
+
+    rocsolver_chetrd( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_A    = ( rocblas_double_complex * ) A_mat;
+    rocblas_double_complex* buff_t    = ( rocblas_double_complex * ) t_vec;
+
+    rocsolver_zhetrd( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  }
+
+  hipFree( buff_d );
+  hipFree( buff_e );
+
+  return FLA_SUCCESS;
+}
+
+FLA_Error FLA_Tridiag_blk_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  return FLA_Tridiag_blk_external_hip( handle, uplo, A, A_hip, t, t_hip );
+}
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
@@ -41,7 +41,7 @@ FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
@@ -1,0 +1,113 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          m_A;
+  int          cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Tridiag_form_Q_check( uplo, A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  m_A      = FLA_Obj_length( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float*    buff_A    = ( float    * ) A_mat;
+    float*    buff_t    = ( float    * ) t_vec;
+
+    rocsolver_sorgtr( handle,
+                      blas_uplo,
+                      m_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double*   buff_A    = ( double   * ) A_mat;
+    double*   buff_t    = ( double   * ) t_vec;
+
+    rocsolver_dorgtr( handle,
+                      blas_uplo,
+                      m_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_A    = ( rocblas_float_complex * ) A_mat;
+    rocblas_float_complex* buff_t    = ( rocblas_float_complex * ) t_vec;
+
+    rocsolver_cungtr( handle,
+                      blas_uplo,
+                      m_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex *buff_A    = ( rocblas_double_complex * ) A_mat;
+    rocblas_double_complex *buff_t    = ( rocblas_double_complex * ) t_vec;
+
+    rocsolver_zungtr( handle,
+                      blas_uplo,
+                      m_A,
+                      buff_A, cs_A,
+                      buff_t );
+
+    break;
+  }
+
+  }
+
+  return FLA_SUCCESS;
+}
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
@@ -37,7 +37,7 @@ FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo,
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
@@ -1,0 +1,133 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+#include "rocsolver.h"
+
+FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  FLA_Datatype datatype;
+  int          n_A, cs_A;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING )
+    FLA_Tridiag_check( uplo, A, t );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  datatype = FLA_Obj_datatype( A );
+
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  void* buff_d;
+  void* buff_e;
+  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A );
+  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ) );
+
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+
+  void* A_mat = NULL;
+  void* t_vec = NULL;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    t_vec = FLA_Obj_buffer_at_view( t );
+  }
+  else
+  {
+    A_mat = A_hip;
+    t_vec = t_hip;
+  }
+
+  switch( datatype ){
+
+  case FLA_FLOAT:
+  {
+    float* buff_A    = ( float * ) A_mat;
+    float* buff_t    = ( float * ) t_vec;
+
+    rocsolver_ssytd2( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  }
+
+  case FLA_DOUBLE:
+  {
+    double* buff_A    = ( double * ) A_mat;
+    double* buff_t    = ( double * ) t_vec;
+
+    rocsolver_dsytd2( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_COMPLEX:
+  {
+    rocblas_float_complex* buff_A    = A_mat;
+    rocblas_float_complex* buff_t    = t_vec;
+
+    rocsolver_chetd2( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  case FLA_DOUBLE_COMPLEX:
+  {
+    rocblas_double_complex* buff_A    = A_mat;
+    rocblas_double_complex* buff_t    = t_vec;
+
+    rocsolver_zhetd2( handle,
+                      blas_uplo,
+                      n_A,
+                      buff_A, cs_A,
+                      buff_d,
+                      buff_e,
+                      buff_t );
+
+    break;
+  } 
+
+  }
+
+  hipFree( buff_d );
+  hipFree( buff_e );
+
+  return FLA_SUCCESS;
+}
+
+FLA_Error FLA_Tridiag_unb_ext_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
+{
+  return FLA_Tridiag_unb_external_hip( handle, uplo, A, A_hip, t, t_hip );
+}
+#endif

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
@@ -41,7 +41,7 @@ FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   void* A_mat = NULL;
   void* t_vec = NULL;
-  if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
   {
     A_mat = FLA_Obj_buffer_at_view( A );
     t_vec = FLA_Obj_buffer_at_view( t );


### PR DESCRIPTION
Details:
- Implement more external LAPACK functionality through rocSOLVER.
        * FLA_Apply_Q_blk_external_hip
        * FLA_Bidiag_apply_U_external_hip
        * FLA_Bidiag_apply_V_external_hip
        * FLA_Bidiag_blk_external_hip
        * FLA_Bidiag_blk_ext_hip
        * FLA_Bidiag_unb_external_hip
        * FLA_Bidiag_unb_ext_hip
        * FLA_Bidiag_form_U_external_hip
        * FLA_Bidiag_form_V_external_hip
        * FLA_Bsvd_external_hip
        * FLA_Eig_gest_blk_external_hip
        * FLA_Eig_gest_il_blk_ext_hip
        * FLA_Eig_gest_iu_blk_ext_hip
        * FLA_Eig_gest_nl_blk_ext_hip
        * FLA_Eig_gest_nu_blk_ext_hip
        * FLA_Eig_gest_unb_external_hip
        * FLA_Eig_gest_il_unb_ext_hip
        * FLA_Eig_gest_iu_unb_ext_hip
        * FLA_Eig_gest_nl_unb_ext_hip
        * FLA_Eig_gest_nu_unb_ext_hip
        * FLA_Hevdd_external_hip
        * FLA_Hevd_external_hip
        * FLA_LU_piv_blk_external_hip
        * FLA_LU_piv_copy_external_hip
        * FLA_LQ_blk_external_hip
        * FLA_LQ_blk_ext_hip
        * FLA_LQ_unb_external_hip
        * FLA_LQ_unb_ext_hip
        * FLA_QR_form_Q_external_hip
        * FLA_QR_unb_external_hip
        * FLA_QR_unb_ext_hip
        * FLA_Svd_external_hip
        * FLA_Tevdd_external_hip
        * FLA_Tevd_external_hip
        * FLA_Tridiag_apply_Q_external_hip
        * FLA_Tridiag_blk_external_hip
        * FLA_Tridiag_blk_ext_hip
        * FLA_Tridiag_form_Q_external_hip
        * FLA_Tridiag_unb_external_hip
        * FLA_Tridiag_unb_ext_hip
- Enable FLA_LU_piv and FLA_LU_piv_copy tasks through HIP wrappers.
- Note: the pivot adjustments currently still happen on CPU but should
      eventually be replaced by helper GPU library functions.
    
Eig_gest wrappers provided by: Zhaoyi Li <zhaoyi.li@amd.com>