### PR TITLE
Implement Eig task for HIP.

### DIFF
--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -334,7 +334,7 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
    // LAPACK
    typedef FLA_Error(*flash_chol_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip );
    typedef FLA_Error(*flash_trinv_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Diag diag, FLA_Obj A, void* A_hip );
-   typedef FLA_Error(*flash_eig_gest_hip_p)(rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj Y, void* Y_hip, FLA_Obj B, void* B_hip );
+   typedef FLA_Error(*flash_eig_gest_hip_p)(rocblas_handle handle, FLA_Inv inv, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
    typedef FLA_Error(*flash_lu_piv_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p );
    typedef FLA_Error(*flash_lu_piv_copy_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip );
 
@@ -394,15 +394,13 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
    else if ( t->func == (void *) FLA_Eig_gest_task )
    {
       flash_eig_gest_hip_p func;
-      func = (flash_eig_gest_hip_p) t->func;
+      func = (flash_eig_gest_hip_p) FLA_Eig_gest_blk_external_hip;
 
       func(                     handle,
             ( FLA_Inv         ) t->int_arg[0],
             ( FLA_Uplo        ) t->int_arg[1],
                                 t->output_arg[1],
                                 output_arg[1],
-                                t->output_arg[0],
-                                output_arg[0],
                                 t->input_arg[0],
                                 input_arg[0] );
    }

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -271,7 +271,7 @@ also to create a macro for when it is not below to return an error code.
                           (void *) cntl, \
                           "Eig  ", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           2, 0, 1, 2, \
                           inv, uplo, \
                           B, Y, A )


### PR DESCRIPTION
Details:
- Use FLA_Eig_gest_blk_external_hip wrapper to rocSOLVER to implement
  the Eig task.
- Passes unit tests and single GPU flash_sm benchmark.
- Fails with matrixes with one dimensions not evenly divisible by the
  block size in Hemm_check - identical behavior to existing CPU path
  with flash_sm.