### PR TITLE
Improve mGPU handling for HIP.

### DIFF
--- a/docs/libflame/40-user-api.tex
+++ b/docs/libflame/40-user-api.tex
@@ -5607,6 +5607,10 @@ parallel.
 }
 \notes{
 This routine does not immediately cause SuperMatrix to spawn any threads.
+
+If HIP is enabled, the choice for number of threads corresponds to the
+number of HIP devices to be used. It must therefore not be larger than the
+number of available devices in the system.
 }
 \begin{params}
 \parameter{\uint}{n\_threads}{An unsigned integer representing the number of threads to be requested upon parallel execution.}

--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -36,7 +36,7 @@ FLA_Error      FLASH_Queue_bind_hip( int thread );
 FLA_Error      FLASH_Queue_alloc_hip( dim_t size, FLA_Datatype datatype, void** buffer_hip );
 FLA_Error      FLASH_Queue_free_hip( void* buffer_hip );
 FLA_Error      FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip );
-FLA_Error      FLASH_Queue_read_hip( FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip );
 
 void           FLASH_Queue_exec_task_hip( FLASH_Task* t, void** input_arg, void** output_arg );
 

--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -25,6 +25,8 @@ FLA_Bool       FLASH_Queue_get_enabled_hip( void );
 
 // --- helper functions -------------------------------------------------------
 
+FLA_Error      FLASH_Queue_available_devices_hip( int* device_count );
+
 FLA_Error      FLASH_Queue_enable_malloc_managed_hip( void );
 FLA_Error      FLASH_Queue_disable_malloc_managed_hip( void );
 FLA_Bool       FLASH_Queue_get_malloc_managed_enabled_hip( void );

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -50,9 +50,8 @@ void FLASH_Queue_init_hip( void )
    for ( int i  = 0; i < device_count; i++ )
    {
       // initialize a rocBLAS handle
-      //hipSetDevice( i );
-      rocblas_create_handle( &(handles[i]) );
       hipSetDevice( i );
+      rocblas_create_handle( &(handles[i]) );
    }
 
    return;

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -84,6 +84,25 @@ void FLASH_Queue_finalize_hip( void )
 }
 
 
+FLA_Error FLASH_Queue_available_devices_hip( int* device_count )
+/*----------------------------------------------------------------------------
+
+   FLASH_Queue_available_devices_hip
+
+----------------------------------------------------------------------------*/
+{
+
+   hipError_t err = hipGetDeviceCount( device_count );
+   if ( err != hipSuccess )
+   {
+     fprintf( stderr, "Failure to get device count: %d\n", err);
+     return FLA_FAILURE;
+   }
+
+   return FLA_SUCCESS;
+}
+
+
 FLA_Error FLASH_Queue_enable_hip( void )
 /*----------------------------------------------------------------------------
 

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -305,8 +305,6 @@ FLA_Error FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip )
      return FLA_SUCCESS; // HMM will take care of getting the memory over
    }
    // Write the contents of a block in main memory to HIP.
-   //hipStream_t stream;
-   //rocblas_get_stream( handle, &stream );
    const size_t count = FLA_Obj_elem_size( obj )
                           * FLA_Obj_col_stride( obj )
                           * FLA_Obj_width( obj );
@@ -314,7 +312,6 @@ FLA_Error FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip )
                                           FLA_Obj_buffer_at_view( obj ),
                                           count,
                                           hipMemcpyHostToDevice,
-                                          //stream );
 					  (hipStream_t) 0 );
 
    if ( err != hipSuccess )
@@ -329,7 +326,6 @@ FLA_Error FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip )
 }
 
 
-//FLA_Error FLASH_Queue_read_hip( FLA_Obj obj, void* buffer_hip )
 FLA_Error FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip )
 /*----------------------------------------------------------------------------
 
@@ -341,9 +337,6 @@ FLA_Error FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip )
    if ( flash_malloc_managed_hip )
    {
      // inject a stream sync on the rocBLAS stream to ensure completion
-     //hipStream_t stream;
-     //rocblas_get_stream( handle, &stream );
-     //hipError_t err = hipStreamSynchronize( stream );
      hipError_t err = hipStreamSynchronize( (hipStream_t) 0 );
      if ( err != hipSuccess )
      {

--- a/src/base/flamec/supermatrix/main/FLASH_Queue.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue.c
@@ -216,6 +216,23 @@ void FLASH_Queue_set_num_threads( unsigned int n_threads )
 
 #endif
 
+#ifdef FLA_ENABLE_HIP
+   // check number of devices to ensure number of threads specified is <= it
+   if ( FLASH_Queue_get_enabled_hip() )
+   {
+      int no_devices = 0;
+      e_val = FLASH_Queue_available_devices_hip( &no_devices );
+      FLA_Check_error_code( e_val );
+      if ( no_devices > n_threads )
+      {
+         fprintf( stderr, "Requesting %d threads but only %d HIP devices available.\n",
+                  n_threads,
+                  no_devices );
+         FLA_Check_error_code( FLA_FAILURE );
+      }
+   }
+#endif
+
    return;
 }
 

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -2269,7 +2269,6 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
 
       // Flush the blocks that are dirty.
       if ( hip_obj.obj.base != NULL && !hip_obj.clean )
-         //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
          FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
       // Free the memory on the HIP for all the blocks.
       FLASH_Queue_free_hip( hip_obj.buffer_hip );
@@ -2757,7 +2756,6 @@ void FLASH_Queue_update_block_hip( FLA_Obj obj,
    // Evict and flush the LRU dirty block.
    if ( evict )
    {
-      //FLASH_Queue_read_hip( evict_obj.obj, evict_obj.buffer_hip );
       FLASH_Queue_read_hip( thread, evict_obj.obj, evict_obj.buffer_hip );
 #ifdef FLA_ENABLE_MULTITHREADING
       FLA_Lock_acquire( &(args->hip_lock[thread]) ); // G ***
@@ -2926,7 +2924,6 @@ void FLASH_Queue_flush_block_hip( FLA_Obj obj, int thread, void *arg )
       return;
 
    // Flush the block outside the critical section.
-   //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
    FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
 
 #ifdef FLA_ENABLE_MULTITHREADING
@@ -3000,7 +2997,6 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
    for ( i = 0; i < n_transfer; i++ )
    {
       hip_obj = args->hip_log[thread * hip_n_blocks + i];
-      //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
       FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
    }
 

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -2269,8 +2269,8 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
 
       // Flush the blocks that are dirty.
       if ( hip_obj.obj.base != NULL && !hip_obj.clean )
-         FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
-
+         //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
+         FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
       // Free the memory on the HIP for all the blocks.
       FLASH_Queue_free_hip( hip_obj.buffer_hip );
    }
@@ -2757,8 +2757,8 @@ void FLASH_Queue_update_block_hip( FLA_Obj obj,
    // Evict and flush the LRU dirty block.
    if ( evict )
    {
-      FLASH_Queue_read_hip( evict_obj.obj, evict_obj.buffer_hip );
-
+      //FLASH_Queue_read_hip( evict_obj.obj, evict_obj.buffer_hip );
+      FLASH_Queue_read_hip( thread, evict_obj.obj, evict_obj.buffer_hip );
 #ifdef FLA_ENABLE_MULTITHREADING
       FLA_Lock_acquire( &(args->hip_lock[thread]) ); // G ***
 #endif
@@ -2926,7 +2926,8 @@ void FLASH_Queue_flush_block_hip( FLA_Obj obj, int thread, void *arg )
       return;
 
    // Flush the block outside the critical section.
-   FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
+   //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
+   FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
 
 #ifdef FLA_ENABLE_MULTITHREADING
    FLA_Lock_acquire( &(args->hip_lock[thread]) ); // G ***
@@ -2999,7 +3000,8 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
    for ( i = 0; i < n_transfer; i++ )
    {
       hip_obj = args->hip_log[thread * hip_n_blocks + i];
-      FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
+      //FLASH_Queue_read_hip( hip_obj.obj, hip_obj.buffer_hip );
+      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
    }
 
 #ifdef FLA_ENABLE_MULTITHREADING


### PR DESCRIPTION
Details:
    - Document that the number of SuperMatrix threads corresponds to the
      number of HIP devices targeted.
    - Add a helper function for the number of available devices and ensure
      the chosen number of threads never exceeds said number.
    - Use a single rocBLAS handle per device.
    - Set the HIP device and select the correct handle per task based on the
      task's targeted thread.
    - Confirmed to work with some performance scaling to 2 GPUs -
      performance and correctness improvements beyond that to follow later.
    
    Contributions by: Zhaoyi Li <zhaoyi.li@amd.com>