### PR TITLE
Fix Eig_gest blocked variants for not fully filled blocks.

### DIFF
--- a/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var1.c
+++ b/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var1.c
@@ -22,10 +22,10 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
-  FLA_Obj Y10_t,
-          Y10_b;
 
   dim_t b;
 
@@ -35,7 +35,8 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,17 +54,17 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_2x1( Y10,   &Y10_t, 
-                         &Y10_b,    b, FLA_TOP );
-
     // Y10 = B10 * A00;
     FLA_Hemm_internal( FLA_RIGHT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A00, B10, FLA_ZERO, Y10_t,
+                       FLA_ONE, A00, B10, FLA_ZERO, Y10,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A10 = A10 * inv( tril( B00 )' );
@@ -73,7 +74,7 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A10 = A10 - 1/2 * Y10;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = A11 - A10 * B10' - B10 * A10';
@@ -87,7 +88,7 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            FLA_Cntl_sub_eig_gest( cntl ) );
 
     // A10 = A10 - 1/2 * Y10;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A10 = inv( tril( B11 ) ) * A10;
@@ -110,8 +111,11 @@ FLA_Error FLA_Eig_gest_il_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var2.c
+++ b/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var2.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_il_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y10_t,
-          Y10_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_il_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,21 +53,21 @@ FLA_Error FLA_Eig_gest_il_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_2x1( Y10,   &Y10_t, 
-                         &Y10_b,    b, FLA_TOP );
-
     // Y10 = 1/2 * B10 * A00;
     FLA_Hemm_internal( FLA_RIGHT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE_HALF, A00, B10, FLA_ZERO, Y10_t,
+                       FLA_ONE_HALF, A00, B10, FLA_ZERO, Y10,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A10 = A10 - Y10;
-    FLA_Axpy_internal( FLA_MINUS_ONE, Y10_t, A10,
+    FLA_Axpy_internal( FLA_MINUS_ONE, Y10, A10,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = A11 - A10 * B10' - B10 * A10';
@@ -92,7 +92,7 @@ FLA_Error FLA_Eig_gest_il_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A10 = A10 - Y10;
-    FLA_Axpy_internal( FLA_MINUS_ONE, Y10_t, A10,
+    FLA_Axpy_internal( FLA_MINUS_ONE, Y10, A10,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A10 = inv( tril( B11 ) ) * A10;
@@ -115,8 +115,11 @@ FLA_Error FLA_Eig_gest_il_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var4.c
+++ b/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var4.c
@@ -20,11 +20,9 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y21_l, Y21_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -34,8 +32,8 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT, 
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,15 +51,13 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01, 
-                        /* ** */              /* *** */
-                                                &Y11, 
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_1x2( Y21,    &Y21_l, &Y21_r,     b, FLA_LEFT );
 
     // A10 = inv( tril( B11 ) ) * A10;
     FLA_Trsm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR, 
@@ -81,7 +77,7 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y21 = B21 * A11;
     FLA_Hemm_internal( FLA_RIGHT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A11, B21, FLA_ZERO, Y21_l,
+                       FLA_ONE, A11, B21, FLA_ZERO, Y21,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A21 = A21 * inv( tril( B11 )' );
@@ -91,7 +87,7 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm2( cntl ) );
 
     // A21 = A21 - 1/2 * Y21;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A22 = A22 - A21 * B21' - B21 * A21';
@@ -100,7 +96,7 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A21 = A21 - 1/2 * Y21;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     /*------------------------------------------------------------*/
@@ -117,10 +113,11 @@ FLA_Error FLA_Eig_gest_il_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01, 
-                                                     Y11, 
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var5.c
+++ b/src/lapack/red/eig/gest/il/flamec/FLA_Eig_gest_il_blk_var5.c
@@ -22,11 +22,9 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y21_l, Y21_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -36,8 +34,8 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT, 
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -55,14 +53,13 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01, 
-                        /* ** */              /* *** */
-                                                &Y11, 
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_1x2( Y21,    &Y21_l, &Y21_r,    b, FLA_LEFT );
 
     // A11 = inv( tril( B11 ) ) * A11 * inv( tril( B11 )' );
     FLA_Eig_gest_internal( FLA_INVERSE, FLA_LOWER_TRIANGULAR,
@@ -71,7 +68,7 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y21 = B21 * A11;
     FLA_Hemm_internal( FLA_RIGHT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A11, B21, FLA_ZERO, Y21_l,
+                       FLA_ONE, A11, B21, FLA_ZERO, Y21,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A21 = A21 * inv( tril( B11 )' );
@@ -81,7 +78,7 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A21 = A21 - 1/2 * Y21;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A22 = A22 - A21 * B21' - B21 * A21';
@@ -90,7 +87,7 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A21 = A21 - 1/2 * Y21;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A21 = inv( tril( B22 ) ) * A21;
@@ -113,10 +110,11 @@ FLA_Error FLA_Eig_gest_il_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01, 
-                                                     Y11, 
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var1.c
+++ b/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var1.c
@@ -22,11 +22,9 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y01_l, Y01_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -36,8 +34,8 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT,
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -55,18 +53,17 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_1x2( Y01,    &Y01_l, &Y01_r,    b, FLA_LEFT );
-
     // Y01 = A00 * B01;
     FLA_Hemm_internal( FLA_LEFT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A00, B01, FLA_ZERO, Y01_l,
+                       FLA_ONE, A00, B01, FLA_ZERO, Y01,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A01 = inv( triu( B00 )' ) * A01;
@@ -76,7 +73,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A01 = A01 - 1/2 * Y01;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = A11 - A01' * B01 - B01' * A01;
@@ -90,7 +87,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            FLA_Cntl_sub_eig_gest( cntl ) );
 
     // A01 = A01 - 1/2 * Y01;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A01 = A01 * inv( triu( B11 ) );
@@ -113,10 +110,11 @@ FLA_Error FLA_Eig_gest_iu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var2.c
+++ b/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var2.c
@@ -22,11 +22,9 @@ FLA_Error FLA_Eig_gest_iu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y01_l, Y01_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -36,8 +34,8 @@ FLA_Error FLA_Eig_gest_iu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT,
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -55,22 +53,21 @@ FLA_Error FLA_Eig_gest_iu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_1x2( Y01,    &Y01_l, &Y01_r,    b, FLA_LEFT );
-
     // Y01 = 1/2 * A00 * B01;
     FLA_Hemm_internal( FLA_LEFT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE_HALF, A00, B01, FLA_ZERO, Y01_l,
+                       FLA_ONE_HALF, A00, B01, FLA_ZERO, Y01,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A01 = A01 - Y01;
-    FLA_Axpy_internal( FLA_MINUS_ONE, Y01_l, A01,
+    FLA_Axpy_internal( FLA_MINUS_ONE, Y01, A01,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = A11 - A01' * B01 - B01' * A01;
@@ -95,7 +92,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A01 = A01 - Y01;
-    FLA_Axpy_internal( FLA_MINUS_ONE, Y01_l, A01,
+    FLA_Axpy_internal( FLA_MINUS_ONE, Y01, A01,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A01 = A01 * inv( triu( B11 ) );
@@ -118,10 +115,11 @@ FLA_Error FLA_Eig_gest_iu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var4.c
+++ b/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var4.c
@@ -20,10 +20,9 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y12_t,
-          Y12_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -33,7 +32,8 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -51,13 +51,13 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_2x1( Y12,    &Y12_t,
-                          &Y12_b,    b, FLA_TOP );
 
     // A01 = A01 * inv( triu( B11 ) );
     FLA_Trsm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
@@ -77,7 +77,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y12 = A11 * B12;
     FLA_Hemm_internal( FLA_LEFT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A11, B12, FLA_ZERO, Y12_t,
+                       FLA_ONE, A11, B12, FLA_ZERO, Y12,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A12 = inv( triu( B11 )' ) * A12;
@@ -87,7 +87,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm2( cntl ) );
 
     // A12 = A12 - 1/2 * Y12;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A22 = A22 - A12' * B12 - B12' * A12;
@@ -96,7 +96,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A12 = A12 - 1/2 * Y12;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     /*------------------------------------------------------------*/
@@ -113,8 +113,11 @@ FLA_Error FLA_Eig_gest_iu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var5.c
+++ b/src/lapack/red/eig/gest/iu/flamec/FLA_Eig_gest_iu_blk_var5.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y12_t,
-          Y12_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,13 +53,13 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_2x1( Y12,    &Y12_t,
-                          &Y12_b,    b, FLA_TOP );
 
     // A11 = inv( triu( B11 )' ) * A11 * inv( triu( B11 ) );
     FLA_Eig_gest_internal( FLA_INVERSE, FLA_UPPER_TRIANGULAR,
@@ -68,7 +68,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y12 = A11 * B12;
     FLA_Hemm_internal( FLA_LEFT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A11, B12, FLA_ZERO, Y12_t,
+                       FLA_ONE, A11, B12, FLA_ZERO, Y12,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A12 = inv( triu( B11 )' ) * A12;
@@ -78,7 +78,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trsm1( cntl ) );
 
     // A12 = A12 - 1/2 * Y12;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A22 = A22 - A12' * B12 - B12' * A12;
@@ -87,7 +87,7 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A12 = A12 - 1/2 * Y12;
-    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_MINUS_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A12 = A12 * inv( triu( B22 ) );
@@ -110,8 +110,11 @@ FLA_Error FLA_Eig_gest_iu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &BBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var1.c
+++ b/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var1.c
@@ -20,11 +20,9 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y21_l, Y21_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -34,8 +32,8 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT, 
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,18 +51,17 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_1x2( Y21,    &Y21_l, &Y21_r,     b, FLA_LEFT );
-
     // Y21 = A22 * B21;
     FLA_Hemm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A22, B21, FLA_ZERO, Y21_l,
+                       FLA_ONE, A22, B21, FLA_ZERO, Y21,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A21 = A21 * tril( B11 );
@@ -74,7 +71,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm1( cntl ) );
 
     // A21 = A21 + 1/2 * Y21;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = tril( B11 )' * A11 * tril( B11 );
@@ -88,7 +85,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A21 = A21 + 1/2 * Y21;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A21 = tril( B22 )' * A21;
@@ -111,10 +108,11 @@ FLA_Error FLA_Eig_gest_nl_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var2.c
+++ b/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var2.c
@@ -20,11 +20,9 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y21_l, Y21_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -34,8 +32,8 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT, 
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,14 +51,13 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_1x2( Y21,    &Y21_l, &Y21_r,     b, FLA_LEFT );
 
     // A10 = tril( B11 )' * A10;
     FLA_Trmm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR,
@@ -75,7 +72,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y21 = A22 * B21;
     FLA_Hemm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A22, B21, FLA_ZERO, Y21_l,
+                       FLA_ONE, A22, B21, FLA_ZERO, Y21,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A21 = A21 * tril( B11 );
@@ -85,7 +82,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm2( cntl ) );
 
     // A21 = A21 + 1/2 * Y21;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = tril( B11 )' * A11 * tril( B11 );
@@ -99,7 +96,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A21 = A21 + 1/2 * Y21;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y21_l, A21,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y21, A21,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     /*------------------------------------------------------------*/
@@ -116,10 +113,11 @@ FLA_Error FLA_Eig_gest_nl_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var4.c
+++ b/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var4.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_nl_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y10_t,
-          Y10_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_nl_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,21 +53,21 @@ FLA_Error FLA_Eig_gest_nl_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_2x1( Y10,   &Y10_t,
-                         &Y10_b,    b, FLA_TOP );
-
     // Y10 = A11 * B10;
     FLA_Hemm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A11, B10, FLA_ZERO, Y10_t,
+                       FLA_ONE, A11, B10, FLA_ZERO, Y10,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A10 = A10 + 1/2 * Y10;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A00 = A00 + A10' * B10 + B10' * A10;
@@ -76,7 +76,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A10 = A10 + 1/2 * Y10;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A10 = tril( B11 )' * A10;
@@ -115,8 +115,11 @@ FLA_Error FLA_Eig_gest_nl_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var5.c
+++ b/src/lapack/red/eig/gest/nl/flamec/FLA_Eig_gest_nl_blk_var5.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y10_t,
-          Y10_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,17 +53,17 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_2x1( Y10,   &Y10_t,
-                         &Y10_b,    b, FLA_TOP );
-
     // Y10 = A11 * B10;
     FLA_Hemm_internal( FLA_LEFT, FLA_LOWER_TRIANGULAR,
-                       FLA_ONE, A11, B10, FLA_ZERO, Y10_t,
+                       FLA_ONE, A11, B10, FLA_ZERO, Y10,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A10 = A10 * tril( B00 );
@@ -73,7 +73,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm1( cntl ) );
 
     // A10 = A10 + 1/2 * Y10;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A00 = A00 + A10' * B10 + B10' * A10;
@@ -82,7 +82,7 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A10 = A10 + 1/2 * Y10;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y10_t, A10,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y10, A10,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A10 = tril( B11 )' * A10;
@@ -110,8 +110,11 @@ FLA_Error FLA_Eig_gest_nl_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var1.c
+++ b/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var1.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y12_t,
-          Y12_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,17 +53,17 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_2x1( Y12,    &Y12_t,
-                          &Y12_b,    b, FLA_TOP );
-
     // Y12 = B12 * A22;
     FLA_Hemm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A22, B12, FLA_ZERO, Y12_t,
+                       FLA_ONE, A22, B12, FLA_ZERO, Y12,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A12 = triu( B11 ) * A12;
@@ -73,7 +73,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm1( cntl ) );
 
     // A12 = A12 + 1/2 * Y12;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = triu( B11 ) * A11 * triu( B11 )';
@@ -87,7 +87,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A12 = A12 + 1/2 * Y12;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A12 = A12 * triu( B22 )';
@@ -110,8 +110,11 @@ FLA_Error FLA_Eig_gest_nu_blk_var1( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var2.c
+++ b/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var2.c
@@ -22,10 +22,9 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YL,    YR,       Y10, Y11, Y12;
-
-  FLA_Obj Y12_t,
-          Y12_b;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -35,7 +34,8 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_1x2( Y,    &YL,  &YR,      0, FLA_LEFT );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,13 +53,13 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_1x2_to_1x3( YL,  /**/ YR,        &Y10, /**/ &Y11, &Y12,
-                           b, FLA_RIGHT );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
-
-    FLA_Part_2x1( Y12,    &Y12_t,
-                          &Y12_b,    b, FLA_TOP );
 
     // A01 = A01 * triu( B11 )';
     FLA_Trmm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
@@ -75,7 +75,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
 
     // Y12 = B12 * A22;
     FLA_Hemm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A22, B12, FLA_ZERO, Y12_t,
+                       FLA_ONE, A22, B12, FLA_ZERO, Y12,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A12 = triu( B11 ) * A12;
@@ -85,7 +85,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm2( cntl ) );
 
     // A12 = A12 + 1/2 * Y12;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A11 = triu( B11 ) * A11 * triu( B11 )';
@@ -99,7 +99,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A12 = A12 + 1/2 * Y12;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y12_t, A12,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y12, A12,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     /*------------------------------------------------------------*/
@@ -116,8 +116,11 @@ FLA_Error FLA_Eig_gest_nu_blk_var2( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_1x3_to_1x2( &YL,  /**/ &YR,        Y10, Y11, /**/ Y12,
-                              FLA_LEFT );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var4.c
+++ b/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var4.c
@@ -20,11 +20,9 @@ FLA_Error FLA_Eig_gest_nu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y01_l, Y01_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -34,8 +32,8 @@ FLA_Error FLA_Eig_gest_nu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT,
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -53,22 +51,21 @@ FLA_Error FLA_Eig_gest_nu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_1x2( Y01,    &Y01_l, &Y01_r,    b, FLA_LEFT );
-
     // Y01 = B01 * A11;
     FLA_Hemm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A11, B01, FLA_ZERO, Y01_l,
+                       FLA_ONE, A11, B01, FLA_ZERO, Y01,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A01 = A01 + 1/2 * Y01;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A00 = A00 + A01 * B01' + B01 * A01';
@@ -77,7 +74,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A01 = A01 + 1/2 * Y01;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A01 = A01 * triu( B11 )';
@@ -116,10 +113,11 @@ FLA_Error FLA_Eig_gest_nu_blk_var4( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;

--- a/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var5.c
+++ b/src/lapack/red/eig/gest/nu/flamec/FLA_Eig_gest_nu_blk_var5.c
@@ -22,11 +22,9 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
           BBL,   BBR,      B10, B11, B12,
                            B20, B21, B22;
 
-  FLA_Obj YT,              Y01,
-          YB,              Y11,
-                           Y21;
-
-  FLA_Obj Y01_l, Y01_r;
+  FLA_Obj YTL,   YTR,      Y00, Y01, Y02,
+          YBL,   YBR,      Y10, Y11, Y12,
+                           Y20, Y21, Y22;
 
   dim_t b;
 
@@ -36,8 +34,8 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
   FLA_Part_2x2( B,    &BTL, &BTR,
                       &BBL, &BBR,     0, 0, FLA_TL );
 
-  FLA_Part_2x1( Y,    &YT,
-                      &YB,            0, FLA_TOP );
+  FLA_Part_2x2( Y,    &YTL, &YTR,
+                      &YBL, &YBR,     0, 0, FLA_TL );
 
   while ( FLA_Obj_length( ATL ) < FLA_Obj_length( A ) ){
 
@@ -55,18 +53,17 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                            BBL, /**/ BBR,       &B20, /**/ &B21, &B22,
                            b, b, FLA_BR );
 
-    FLA_Repart_2x1_to_3x1( YT,                  &Y01,
-                        /* ** */              /* *** */
-                                                &Y11,
-                           YB,                  &Y21,        b, FLA_BOTTOM );
+    FLA_Repart_2x2_to_3x3( YTL, /**/ YTR,       &Y00, /**/ &Y01, &Y02,
+                        /* ************* */   /* ******************** */
+                                                &Y10, /**/ &Y11, &Y12,
+                           YBL, /**/ YBR,       &Y20, /**/ &Y21, &Y22,
+                           b, b, FLA_BR );
 
     /*------------------------------------------------------------*/
 
-    FLA_Part_1x2( Y01,    &Y01_l, &Y01_r,    b, FLA_LEFT );
-
     // Y01 = B01 * A11;
     FLA_Hemm_internal( FLA_RIGHT, FLA_UPPER_TRIANGULAR,
-                       FLA_ONE, A11, B01, FLA_ZERO, Y01_l,
+                       FLA_ONE, A11, B01, FLA_ZERO, Y01,
                        FLA_Cntl_sub_hemm( cntl ) );
 
     // A01 = triu( B00 ) * A01;
@@ -76,7 +73,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                        FLA_Cntl_sub_trmm1( cntl ) );
 
     // A01 = A01 + 1/2 * Y01;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy1( cntl ) );
 
     // A00 = A00 + A01 * B01' + B01 * A01';
@@ -85,7 +82,7 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                         FLA_Cntl_sub_her2k( cntl ) );
 
     // A01 = A01 + 1/2 * Y01;
-    FLA_Axpy_internal( FLA_ONE_HALF, Y01_l, A01,
+    FLA_Axpy_internal( FLA_ONE_HALF, Y01, A01,
                        FLA_Cntl_sub_axpy2( cntl ) );
 
     // A01 = A01 * triu( B11 )';
@@ -113,10 +110,11 @@ FLA_Error FLA_Eig_gest_nu_blk_var5( FLA_Obj A, FLA_Obj Y, FLA_Obj B, fla_eig_ges
                               &BBL, /**/ &BBR,       B20, B21, /**/ B22,
                               FLA_TL );
 
-    FLA_Cont_with_3x1_to_2x1( &YT,                   Y01,
-                                                     Y11,
-                            /* ** */              /* *** */
-                              &YB,                   Y21,     FLA_TOP );
+    FLA_Cont_with_3x3_to_2x2( &YTL, /**/ &YTR,       Y00, Y01, /**/ Y02,
+                                                     Y10, Y11, /**/ Y12,
+                            /* ************** */  /* ****************** */
+                              &YBL, /**/ &YBR,       Y20, Y21, /**/ Y22,
+                              FLA_TL );
   }
 
   return FLA_SUCCESS;


### PR DESCRIPTION
Details:
- In FLASH, if the matrix dimension for Eig_gest is not a multiple of
  the block size, intermediate Y work space becomes non-conformant.
- Fix this for all variants by partioning Y identially to A, B.