### PR TITLE
Support CONJUGATE_NO_TRANSPOSE for triangular matrices.

### DIFF
--- a/src/base/flamec/include/FLA_blas1_prototypes.h
+++ b/src/base/flamec/include/FLA_blas1_prototypes.h
@@ -110,6 +110,8 @@ FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A
 FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
+
+FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, void* B_mat );
 #endif
 
 // --- check routine prototypes ------------------------------------------------

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
@@ -76,7 +76,7 @@ FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, F
         for ( int j = 0; j < min( n_A, m_A ); j++)
         {
           dim_t n_elem = n_elem_max - j;
-          dim_t offset = j * ldim_A + j  + 1; // plus one for the imaginary part
+          dim_t offset = 2 * ( j * ldim_A + j )  + 1; // plus one for the imaginary part
           rocblas_sscal( handle,         
                          n_elem,
                          &buff_alpha,
@@ -94,7 +94,7 @@ FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, F
         for ( int j = 0; j < min( n_A, m_A); j++)
         {
           dim_t n_elem = n_elem_max - j;
-          dim_t offset = j * ldim_A + j + 1; // plus one for the imaginary part
+          dim_t offset = 2 * ( j * ldim_A + j ) + 1; // plus one for the imaginary part
           rocblas_dscal( handle,     
                          n_elem,
                          &buff_alpha,
@@ -120,7 +120,7 @@ FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, F
 	for ( int j = 0; j < n_A; j++)
         {
           dim_t n_elem = min( j + 1, n_elem_max );
-	  dim_t offset = j * ldim_A + 1; // plus one for the imaginary part
+	  dim_t offset = 2 * ( j * ldim_A ) + 1; // plus one for the imaginary part
 	  rocblas_sscal( handle,
                          n_elem,
                          &buff_alpha,
@@ -138,7 +138,7 @@ FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, F
         for ( int j = 0; j < n_A; j++)
         {
           dim_t n_elem = min( j + 1, n_elem_max );
-          dim_t offset = j * ldim_A + 1; // plus one for the imaginary part
+          dim_t offset = 2 * ( j * ldim_A ) + 1; // plus one for the imaginary part
           rocblas_dscal( handle,         
                          n_elem,
                          &buff_alpha,

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
@@ -1,0 +1,156 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include <hip/hip_runtime.h>
+#include "rocblas.h"
+
+FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, void* B_mat )
+{
+
+  if ( FLA_Obj_has_zero_dim( A ) )
+  {
+    return FLA_SUCCESS;
+  }
+
+  void* A_mat;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+  }
+  else
+  {
+    A_mat = A_hip;
+  }
+
+  dim_t m_A      = FLA_Obj_length( A );
+  dim_t n_A      = FLA_Obj_width( A );
+  dim_t ldim_A   = FLA_Obj_col_stride( A );
+
+  dim_t elem_size = FLA_Obj_elem_size( A );
+
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  size_t count = elem_size * ldim_A * n_A;
+  hipError_t err = hipMemcpyAsync( B_mat,
+                                   A_mat,
+                                   count,
+                                   hipMemcpyDeviceToDevice,
+                                   stream );
+  if ( err != hipSuccess )
+  {
+    fprintf( stderr,
+             "Failure to copy block HIP2HIP device. Size=%ld, err=%d\n",
+             count, err );
+    return FLA_FAILURE;
+  }
+
+  // early return if for whatever reason a real object was passed
+  if ( FLA_Obj_is_real( A ) ) return FLA_SUCCESS;
+
+  FLA_Datatype datatype = FLA_Obj_datatype( A );
+
+  if ( uplo == FLA_LOWER_TRIANGULAR )
+  {
+    // lower triangular
+    dim_t n_elem_max = m_A;
+    switch ( datatype ){
+
+      case FLA_COMPLEX:
+      {
+
+        float* buff_B_hip = ( float* ) B_mat;
+        float buff_alpha  = -1.0f;
+
+        for ( int j = 0; j < min( n_A, m_A ); j++)
+        {
+          dim_t n_elem = n_elem_max - j;
+          dim_t offset = j * ldim_A + j  + 1; // plus one for the imaginary part
+          rocblas_sscal( handle,         
+                         n_elem,
+                         &buff_alpha,
+                         buff_B_hip + offset, 2 );
+        }
+
+        break;
+      }
+      case FLA_DOUBLE_COMPLEX:
+      {
+
+        double* buff_B_hip = ( double* ) B_mat;
+        double buff_alpha = -1.0;
+
+        for ( int j = 0; j < min( n_A, m_A); j++)
+        {
+          dim_t n_elem = n_elem_max - j;
+          dim_t offset = j * ldim_A + j + 1; // plus one for the imaginary part
+          rocblas_dscal( handle,     
+                         n_elem,
+                         &buff_alpha,
+                         buff_B_hip + offset, 2 );
+        }
+
+        break;
+      }
+    }
+  }
+  else
+  {
+    // upper triangular
+    dim_t n_elem_max = min( m_A, n_A );
+    switch ( datatype ){
+
+      case FLA_COMPLEX:
+      {
+
+        float* buff_B_hip = ( float* ) B_mat;
+        float buff_alpha  = -1.0f;
+
+	for ( int j = 0; j < n_A; j++)
+        {
+          dim_t n_elem = min( j + 1, n_elem_max );
+	  dim_t offset = j * ldim_A + 1; // plus one for the imaginary part
+	  rocblas_sscal( handle,
+                         n_elem,
+                         &buff_alpha,
+                         buff_B_hip + offset, 2 );
+        }
+
+        break;
+      }
+      case FLA_DOUBLE_COMPLEX:
+      {
+
+        double* buff_B_hip = ( double* ) B_mat;
+        double buff_alpha = -1.0;
+
+        for ( int j = 0; j < n_A; j++)
+        {
+          dim_t n_elem = min( j + 1, n_elem_max );
+          dim_t offset = j * ldim_A + 1; // plus one for the imaginary part
+          rocblas_dscal( handle,         
+                         n_elem,
+                         &buff_alpha,
+                         buff_B_hip + offset, 2 );
+        }
+
+        break;
+      }
+    }
+  }
+
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -13,6 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
+#include <hip/hip_runtime.h>
 #include "rocblas.h"
 
 FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
@@ -46,9 +47,6 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   else
     k_AB = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
-  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-
   void* A_mat = NULL;
   void* B_mat = NULL;
   void* C_mat = NULL;
@@ -64,6 +62,26 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
     B_mat = B_hip;
     C_mat = C_hip;
   }
+
+  FLA_Trans trans_a_corr = trans;
+  FLA_Bool conj_no_trans_a = FALSE;
+
+  void* A_mat_corr = NULL;
+  if ( FLA_Obj_is_complex( A ) && trans == FLA_CONJ_NO_TRANSPOSE )
+  {
+    // must correct by copying to temporary buffer and conjugating there
+    trans_a_corr = FLA_NO_TRANSPOSE;
+    conj_no_trans_a = TRUE;
+
+    dim_t elem_size = FLA_Obj_elem_size( A );
+    size_t count = elem_size * ldim_A * n_A;
+    hipMalloc( &A_mat_corr, count );
+    FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
+    A_mat = A_mat_corr;
+  }
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans_a_corr, FLA_Obj_is_real( A ) );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
   switch( datatype ){
 
@@ -144,7 +162,12 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
   }
 
   }
- 
+
+  if( conj_no_trans_a )
+  {
+    hipFree( A_mat_corr );
+  }
+
   return FLA_SUCCESS;
 }
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -13,6 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
+#include <hip/hip_runtime.h>
 #include "rocblas.h"
 
 FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
@@ -43,9 +44,6 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   else
     k_A = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
-  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-
   void* A_mat = NULL;
   void* C_mat = NULL;
   if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
@@ -58,6 +56,26 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
     A_mat = A_hip;
     C_mat = C_hip;
   }
+
+  FLA_Trans trans_a_corr = trans;
+  FLA_Bool conj_no_trans_a = FALSE;
+
+  void* A_mat_corr = NULL;
+  if ( FLA_Obj_is_complex( A ) && trans == FLA_CONJ_NO_TRANSPOSE )
+  {
+    // must correct by copying to temporary buffer and conjugating there
+    trans_a_corr = FLA_NO_TRANSPOSE;
+    conj_no_trans_a = TRUE;
+
+    dim_t elem_size = FLA_Obj_elem_size( A );
+    size_t count = elem_size * ldim_A * n_A;
+    hipMalloc( &A_mat_corr, count );
+    FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
+    A_mat = A_mat_corr;
+  }
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans_a_corr, FLA_Obj_is_real( A ) );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
   switch( datatype ){
 
@@ -134,7 +152,12 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   }
 
   }
- 
+
+  if( conj_no_trans_a )
+  {
+    hipFree( A_mat_corr );
+  }
+
   return FLA_SUCCESS;
 }
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -13,6 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
+#include <hip/hip_runtime.h>
 #include "rocblas.h"
 
 FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
@@ -43,9 +44,6 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   else
     k_A = m_A;
 
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
-  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-
   void* A_mat = NULL;
   void* C_mat = NULL;
   if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
@@ -58,6 +56,26 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
     A_mat = A_hip;
     C_mat = C_hip;
   }
+
+  FLA_Trans trans_a_corr = trans;
+  FLA_Bool conj_no_trans_a = FALSE;
+
+  void* A_mat_corr = NULL;
+  if ( FLA_Obj_is_complex( A ) && trans == FLA_CONJ_NO_TRANSPOSE )
+  {
+    // must correct by copying to temporary buffer and conjugating there
+    trans_a_corr = FLA_NO_TRANSPOSE;
+    conj_no_trans_a = TRUE;
+
+    dim_t elem_size = FLA_Obj_elem_size( A );
+    size_t count = elem_size * ldim_A * n_A;
+    hipMalloc( &A_mat_corr, count );
+    FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
+    A_mat = A_mat_corr;
+  }
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans_a_corr, FLA_Obj_is_real( A ) );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
   switch( datatype ){
 
@@ -134,7 +152,12 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
   }
 
   }
-  
+
+  if( conj_no_trans_a )
+  {
+    hipFree( A_mat_corr );
+  }
+
   return FLA_SUCCESS;
 }
 

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -13,11 +13,13 @@
 
 #ifdef FLA_ENABLE_HIP
 
+#include <hip/hip_runtime.h>
 #include "rocblas.h"
 
 FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {
   FLA_Datatype datatype;
+  int          n_A;
   int          m_B, n_B;
   int          ldim_A;
   int          ldim_B;
@@ -30,15 +32,11 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
   datatype = FLA_Obj_datatype( A );
 
   ldim_A   = FLA_Obj_col_stride( A );
+  n_A      = FLA_Obj_width( A );
 
   m_B      = FLA_Obj_length( B );
   n_B      = FLA_Obj_width( B );
   ldim_B   = FLA_Obj_col_stride( B );
-
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
-  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
-  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
   void* A_mat = NULL;
   void* B_mat = NULL;
@@ -52,6 +50,28 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
     A_mat = A_hip;
     B_mat = B_hip;
   }
+
+  FLA_Trans trans_a_corr = trans;
+  FLA_Bool conj_no_trans_a = FALSE;
+
+  void* A_mat_corr = NULL;
+  if ( FLA_Obj_is_complex( A ) && trans == FLA_CONJ_NO_TRANSPOSE )
+  {
+    // must correct by copying to temporary buffer and conjugating there
+    trans_a_corr = FLA_NO_TRANSPOSE;
+    conj_no_trans_a = TRUE;
+
+    dim_t elem_size = FLA_Obj_elem_size( A );
+    size_t count = elem_size * ldim_A * n_A;
+    hipMalloc( &A_mat_corr, count );
+    FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
+    A_mat = A_mat_corr;
+  }
+
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans_a_corr, FLA_Obj_is_real( A ) );
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_diagonal blas_diag = FLA_Param_map_flame_to_rocblas_diag( diag );
 
   switch( datatype ){
 
@@ -127,6 +147,11 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
     break;
   }
 
+  }
+
+  if( conj_no_trans_a )
+  {
+    hipFree( A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
@@ -20,7 +20,7 @@
 FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
 {
   FLA_Datatype datatype;
-  // int          m_A, n_A;
+  int          n_A;
   int          m_B, n_B;
   int          cs_A;
   int          cs_B;
@@ -32,17 +32,12 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
 
   datatype = FLA_Obj_datatype( A );
 
-  // m_A      = FLA_Obj_length( A );
-  // n_A      = FLA_Obj_width( A );
+  n_A      = FLA_Obj_width( A );
   cs_A     = FLA_Obj_col_stride( A );
 
   m_B      = FLA_Obj_length( B );
   n_B      = FLA_Obj_width( B );
   cs_B     = FLA_Obj_col_stride( B );
-
-  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
-  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
-  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans, FLA_Obj_is_real( A ) );
 
   void* A_mat = NULL;
   void* t_vec = NULL;
@@ -59,6 +54,27 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
     t_vec = t_hip;
     B_mat = B_hip;
   }
+
+  FLA_Trans trans_a_corr = trans;
+  FLA_Bool conj_no_trans_a = FALSE;
+
+  void* A_mat_corr = NULL;
+  if ( FLA_Obj_is_complex( A ) && trans == FLA_CONJ_NO_TRANSPOSE )
+  {
+    // must correct by copying to temporary buffer and conjugating there
+    trans_a_corr = FLA_NO_TRANSPOSE;
+    conj_no_trans_a = TRUE;
+
+    dim_t elem_size = FLA_Obj_elem_size( A );
+    size_t count = elem_size * cs_A * n_A;
+    hipMalloc( &A_mat_corr, count );
+    FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
+    A_mat = A_mat_corr;
+  }
+
+  rocblas_side blas_side = FLA_Param_map_flame_to_rocblas_side( side );
+  rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
+  rocblas_operation blas_trans = FLA_Param_map_flame_to_rocblas_trans( trans_a_corr, FLA_Obj_is_real( A ) );
 
   switch( datatype ){
   
@@ -137,6 +153,11 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
   
       break;
     }
+  }
+
+  if( conj_no_trans_a )
+  {
+    hipFree( A_mat_corr );
   }
 
   return FLA_SUCCESS;


### PR DESCRIPTION
Details:
-  Follow the CPU logic to support CONJUGATE_NO_TRANSPOSE where an intermediate buffer is allocated, the matrix is copied into it, and the imaginary part of the complex number is conjugated.
-  Integrate this into Trmm/Trsm/Trsv/Syrk/Syr2k/Herk/Her2k/Tridiag_apply_Q.