### PR TITLE
Add FLA_Copyr task for HIP.

### DIFF
--- a/src/base/flamec/include/FLA_blas1_prototypes.h
+++ b/src/base/flamec/include/FLA_blas1_prototypes.h
@@ -108,6 +108,7 @@ FLA_Error FLA_Scalr_external_gpu( FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void*
 #ifdef FLA_ENABLE_HIP
 FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
 FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_gpu, FLA_Obj B, void* B_gpu );
+FLA_Error FLA_Copyr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip );
 FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_gpu );
 #endif

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -405,6 +405,7 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
    // Level-1 BLAS
    typedef FLA_Error(*flash_axpy_hip_p)(rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip);
    typedef FLA_Error(*flash_copy_hip_p)(rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip);
+   typedef FLA_Error(*flash_copyr_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip);
    typedef FLA_Error(*flash_scal_hip_p)(rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip);
    typedef FLA_Error(*flash_scalr_hip_p)(rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip);
 
@@ -690,6 +691,19 @@ void FLASH_Queue_exec_task_hip( FLASH_Task* t,
                             input_arg[0],
                             t->output_arg[0],
                             output_arg[0] );
+   }
+   // FLA_Copyr
+   else if ( t->func == (void *) FLA_Copyr_task )
+   {
+      flash_copyr_hip_p func;
+      func = (flash_copyr_hip_p) FLA_Copyr_external_hip;
+
+      func(                  handle,
+            ( FLA_Uplo     ) t->int_arg[0],
+                             t->input_arg[0],
+                             input_arg[0],
+                             t->output_arg[0],
+                             output_arg[0] );
    }
    // FLA_Scal
    else if ( t->func == (void *) FLA_Scal_task )

--- a/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
+++ b/src/base/flamec/supermatrix/include/FLASH_Queue_macro_defs.h
@@ -445,9 +445,9 @@ also to create a macro for when it is not below to return an error code.
 #define ENQUEUE_FLASH_Copyr( uplo, A, B, cntl ) \
         FLASH_Queue_push( (void *) FLA_Copyr_task, \
                           (void *) cntl, \
-                          "Copyt", \
+                          "Copyr", \
                           FALSE, \
-                          FALSE, \
+                          TRUE, \
                           1, 0, 1, 1, \
                           uplo, \
                           A, B )

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
@@ -1,0 +1,105 @@
+/*
+
+    Copyright (C) 2014, The University of Texas at Austin
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_HIP
+
+#include "hip/hip_runtime_api.h"
+#include "rocblas.h"
+
+FLA_Error FLA_Copyr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
+{
+  dim_t          m_A, n_A;
+  dim_t          cs_A;
+  dim_t          cs_B;
+
+  if ( FLA_Check_error_level() == FLA_FULL_ERROR_CHECKING ) 
+    FLA_Copyr_check( uplo, A, B );
+
+  if ( FLA_Obj_has_zero_dim( A ) ) return FLA_SUCCESS;
+
+  m_A      = FLA_Obj_length( A );
+  n_A      = FLA_Obj_width( A );
+  cs_A     = FLA_Obj_col_stride( A );
+
+  cs_B     = FLA_Obj_col_stride( B );
+
+  dim_t elem_size = FLA_Obj_elem_size( B );
+
+  void* A_mat;
+  void* B_mat;
+  if ( FLASH_Queue_get_malloc_managed_enabled_hip() )
+  {
+    A_mat = FLA_Obj_buffer_at_view( A );
+    B_mat = FLA_Obj_buffer_at_view( B );
+  }
+  else
+  {
+    A_mat = A_hip;
+    B_mat = B_hip;
+  }
+
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+
+  if ( uplo == FLA_LOWER_TRIANGULAR )
+  {
+    // lower triangular
+    dim_t n_elem_max = m_A;
+    for ( int j = 0; j < min( n_A, m_A ); j++)
+    {
+      dim_t n_elem = n_elem_max - j;
+      dim_t count = elem_size * n_elem;
+      dim_t offset_A = elem_size * ( j * cs_A + j );
+      dim_t offset_B = elem_size * ( j * cs_B + j );
+      hipError_t err = hipMemcpyAsync( B_mat + offset_B,
+                                       A_mat + offset_A,
+                                       count,
+                                       hipMemcpyDeviceToDevice,
+                                       stream );
+      if ( err != hipSuccess )
+      {
+        fprintf( stderr,
+                 "Failure to copy block HIP2HIP device. Size=%ld, err=%d\n",
+                 count, err );
+        return FLA_FAILURE;
+      }
+    }
+  }
+  else
+  {
+    // upper triangular
+    dim_t n_elem_max = min( m_A, n_A );
+    for ( int j = 0; j < n_A; j++)
+    {
+      dim_t n_elem = min( j + 1, n_elem_max );
+      dim_t count = elem_size * n_elem;
+      dim_t offset_A = elem_size * ( j * cs_A );
+      dim_t offset_B = elem_size * ( j * cs_B );
+      hipError_t err = hipMemcpyAsync( B_mat + offset_B,
+                                       A_mat + offset_A,
+                                       count,
+                                       hipMemcpyDeviceToDevice,
+                                       stream );
+      if ( err != hipSuccess )
+      {
+        fprintf( stderr,
+                 "Failure to copy block HIP2HIP device. Size=%ld, err=%d\n",
+                 count, err );
+        return FLA_FAILURE;
+      }
+    }
+  }
+  
+  return FLA_SUCCESS;
+}
+
+#endif

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
@@ -1,6 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2022, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level


### PR DESCRIPTION
Details:
* FLA_Copyr is implemented through repeat invocations of hipMemcpyAsync
  of the populated columns of the triangular matrix.
* While here, correct the task name (Copyt->Copyr).