### PR TITLE
Update rocblas/rocsolver header includes.

### DIFF
--- a/src/base/flamec/include/FLA_blas1_prototypes.h
+++ b/src/base/flamec/include/FLA_blas1_prototypes.h
@@ -9,7 +9,7 @@
 */
 
 #ifdef FLA_ENABLE_HIP
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 #endif
 
 // --- top-level wrapper prototypes --------------------------------------------

--- a/src/base/flamec/include/FLA_blas2_prototypes.h
+++ b/src/base/flamec/include/FLA_blas2_prototypes.h
@@ -9,7 +9,7 @@
 */
 
 #ifdef FLA_ENABLE_HIP
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 #endif
 
 // --- top-level wrapper prototypes --------------------------------------------

--- a/src/base/flamec/include/FLA_blas3_prototypes.h
+++ b/src/base/flamec/include/FLA_blas3_prototypes.h
@@ -9,7 +9,7 @@
 */
 
 #ifdef FLA_ENABLE_HIP
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 #endif
 
 // --- top-level wrapper prototypes --------------------------------------------

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -9,8 +9,8 @@
 */
 
 #ifdef FLA_ENABLE_HIP
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #endif
 
 // -----------------------------------------------------------------------------

--- a/src/base/flamec/main/FLA_Param.c
+++ b/src/base/flamec/main/FLA_Param.c
@@ -10,8 +10,8 @@
 
 #include "FLAME.h"
 #ifdef FLA_ENABLE_HIP
-#include <rocblas.h>
-#include <rocsolver.h>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #endif
 
 // --- FLAME to BLAS/LAPACK mappings -------------------------------------------

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -15,7 +15,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime.h"
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 
 static FLA_Bool flash_queue_enabled_hip  = FALSE;

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Axpy_external_hip.c
@@ -13,7 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Axpy_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copy_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_general_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_general_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Copyconj_general_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, void* B_mat )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyconj_tri_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Copyconj_tri_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, void* B_mat )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Copyr_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Copyr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scal_external_hip.c
@@ -13,7 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Scal_external_hip( rocblas_handle handle, FLA_Obj alpha, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
+++ b/src/base/flamec/wrappers/blas/1/hip/FLA_Scalr_external_hip.c
@@ -13,7 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Scalr_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip, FLA_Obj beta, FLA_Obj y, void* y_hip )
 {

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj A, void* A_hip, FLA_Obj x, void* x_hip ) 
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Trans transb, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Hemm_external_hip.c
@@ -13,7 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Hemm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Symm_external_hip.c
@@ -13,7 +13,7 @@
 
 #ifdef FLA_ENABLE_HIP
 
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Symm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj beta, FLA_Obj C, void* C_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -14,7 +14,7 @@
 #ifdef FLA_ENABLE_HIP
 
 #include <hip/hip_runtime.h>
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 
 FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Diag diag, FLA_Obj alpha, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Store storev, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_U_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_form_U_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_form_V_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_form_V_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj tu, void* tu_hip, FLA_Obj tv, void* tv_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bsvd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Bsvd_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Chol_l_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Chol_unb_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Chol_l_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_blk_external_hip.c
@@ -13,8 +13,8 @@
 
 #ifdef FLA_ENABLE_HIP
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 
 FLA_Error FLA_Eig_gest_il_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Eig_gest_unb_external_hip.c
@@ -13,8 +13,8 @@
 
 #ifdef FLA_ENABLE_HIP
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Eig_gest_il_unb_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Hevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Hevdd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Hevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj e, void* e_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_LQ_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LQ_unb_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_LQ_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_LU_piv_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_copy_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_LU_piv_copy_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_LU_piv_copy_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj p, FLA_Obj U, void* U_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_form_Q_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_QR_form_Q_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_QR_unb_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_QR_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Svd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Svd_external_hip( rocblas_handle handle, FLA_Svd_type jobu, FLA_Svd_type jobv, FLA_Obj A, void* A_hip, FLA_Obj s, void* s_hip, FLA_Obj U, void* U_hip, FLA_Obj V, void* V_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tevd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tevdd_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tevdd_external_hip( rocblas_handle handle, FLA_Evd_type jobz, FLA_Obj d, void* d_hip, FLA_Obj e, void* e_hip, FLA_Obj A, void* A_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo uplo, FLA_Trans trans, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip, FLA_Obj B, void* B_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_form_Q_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tridiag_form_Q_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Obj A, void* A_hip, FLA_Obj t, void* t_hip )
 {

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Trinv_blk_external_hip.c
@@ -14,8 +14,8 @@
 #ifdef FLA_ENABLE_HIP
 
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 
 
 FLA_Error FLA_Trinv_ln_blk_ext_hip( rocblas_handle handle, FLA_Obj A, void* A_hip )


### PR DESCRIPTION
Details:
- As of ROCm 5.2, using the rocblas/rocsolver headers in /opt/rocm/include is deprecated.
- Adjust to include rocblas/rocblas.h and rocsolver/rocsolver.h instead.