### PR TITLE
Improve tail performance of HIP backend

### DIFF
--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -39,6 +39,9 @@ FLA_Error      FLASH_Queue_alloc_hip( dim_t size, FLA_Datatype datatype, void** 
 FLA_Error      FLASH_Queue_free_hip( void* buffer_hip );
 FLA_Error      FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip );
 FLA_Error      FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_read_async_hip( int thread, FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_sync_device_hip( int device );
+FLA_Error      FLASH_Queue_sync_hip( );
 
 void           FLASH_Queue_exec_task_hip( FLASH_Task* t, void** input_arg, void** output_arg );
 

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -3007,7 +3007,7 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
       hip_obj = args->hip_log[thread * hip_n_blocks];
       FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
    }
-   else if ( n_transfer == 2 && FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+   else if ( n_transfer == 2 && !FLASH_Queue_get_malloc_managed_enabled_hip( ) )
    {
       // two sync memcpys are faster typically than two async plus device sync
       hip_obj = args->hip_log[thread * hip_n_blocks];

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -2266,6 +2266,10 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
    if ( !FLASH_Queue_get_enabled_hip() )
       return;
 
+   // Exit if managed memory is used
+   if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+      return;
+
    // Examine every block left on the HIP device.
    for ( i = 0; i < hip_n_blocks; i++ )
    {
@@ -2273,10 +2277,9 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
 
       // Flush the blocks that are dirty.
       if ( hip_obj.obj.base != NULL && !hip_obj.clean )
-         FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+         FLASH_Queue_read_async_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
       // Free the memory on the HIP for all the blocks.
-      if ( ! FLASH_Queue_get_malloc_managed_enabled_hip() )
-         FLASH_Queue_free_hip( hip_obj.buffer_hip );
+      FLASH_Queue_free_hip( hip_obj.buffer_hip );
    }
 
    return;
@@ -2998,11 +3001,28 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
    if ( n_transfer == 0 )
       return;
 
-   // Flush the block outside the critical section.
-   for ( i = 0; i < n_transfer; i++ )
+   // Flush the block(s) outside the critical section.
+   if ( n_transfer == 1 )
    {
-      hip_obj = args->hip_log[thread * hip_n_blocks + i];
+      hip_obj = args->hip_log[thread * hip_n_blocks];
       FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+   }
+   else if ( n_transfer == 2 && FLASH_Queue_get_malloc_managed_enabled_hip( ) )
+   {
+      // two sync memcpys are faster typically than two async plus device sync
+      hip_obj = args->hip_log[thread * hip_n_blocks];
+      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+      hip_obj = args->hip_log[thread * hip_n_blocks + 1];
+      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+   }
+   else
+   {
+      for ( i = 0; i < n_transfer; i++ )
+      {
+         hip_obj = args->hip_log[thread * hip_n_blocks + i];
+         FLASH_Queue_read_async_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+      }
+      FLASH_Queue_sync_device_hip( thread );
    }
 
 #ifdef FLA_ENABLE_MULTITHREADING
@@ -3318,6 +3338,7 @@ void* FLASH_Queue_exec_parallel_function( void* arg )
 #ifdef FLA_ENABLE_HIP
    // Destroy and flush contents of accelerators back to main memory.
    FLASH_Queue_destroy_hip( i, ( void* ) args );
+   FLASH_Queue_sync_hip( );
 #endif
    
 #if FLA_MULTITHREADING_MODEL == FLA_PTHREADS


### PR DESCRIPTION
Details:
- introduce async read method and device/stream synchronize methods for the HIP queue
- use these instead of multiple synchronous reads to improve performance by reducing redundant synchronization
- lazily initialize the rocblas_handles and only for devices actually request. I.e., a single SuperMatrix thread run will now only initialize handle 0 - not handles 0...#HIP devices

With contributions from Zhaoyi Li <zhaoyi.li@amd.com>