### PR TITLE
Make sure `lsame_` is exported

### DIFF
--- a/src/map/lapack2flamec/f2c/install/static/lsame.c
+++ b/src/map/lapack2flamec/f2c/install/static/lsame.c
@@ -14,7 +14,7 @@
 #include "FLA_f2c.h"
 #include "stdio.h"
 
-#ifdef FLA_ENABLE_LAPACK2FLAME
+#if defined(FLA_ENABLE_LAPACK2FLAME) || ! defined(FLA_ENABLE_BUILTIN_BLAS)
 logical lsame_(char *ca, char *cb)
 {
     /* System generated locals */


### PR DESCRIPTION
The reference (netlib) LAPACK implementation exports `lsame_` unconditionally. When trying to use libflame as a drop-in replacement for the reference implementation on Windows, programs fail to start with an error that the symbol `lsame_` is undefined. IIUC, that is because the symbol resolution is done on link time for Windows (instead of at runtime on most other platforms).

The proposed change makes sure that `lsame_` is exported from libflame even if configured with `--disable-lapack2flame --disable-builtin-blas` (the default).

IIUC, an alternative would be to export this symbol defined in `src/flablas/f2c/lsame.c`. But the proposed change is a bit closer to the reference implementation.

See also this downstream report: https://savannah.gnu.org/bugs/index.php?63184