### PR TITLE
Increase use of async operations for HIP backend.

### DIFF
--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -36,7 +36,7 @@ dim_t          FLASH_Queue_get_hip_num_blocks( void );
 
 FLA_Error      FLASH_Queue_bind_hip( int thread );
 FLA_Error      FLASH_Queue_alloc_hip( dim_t size, FLA_Datatype datatype, void** buffer_hip );
-FLA_Error      FLASH_Queue_free_hip( void* buffer_hip );
+FLA_Error      FLASH_Queue_free_async_hip( void* buffer_hip );
 FLA_Error      FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip );
 FLA_Error      FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip );
 FLA_Error      FLASH_Queue_read_async_hip( int thread, FLA_Obj obj, void* buffer_hip );

--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -288,15 +288,15 @@ FLA_Error FLASH_Queue_alloc_hip( dim_t size,
 }
 
 
-FLA_Error FLASH_Queue_free_hip( void* buffer_hip )
+FLA_Error FLASH_Queue_free_async_hip( void* buffer_hip )
 /*----------------------------------------------------------------------------
 
-   FLASH_Queue_free_hip
+   FLASH_Queue_free_async_hip
 
 ----------------------------------------------------------------------------*/
 {
    // Free memory for a block on HIP.
-   hipFree( buffer_hip );
+   hipFreeAsync( (hipStream_t) 0, buffer_hip );
 
    return FLA_SUCCESS;
 }

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -2279,7 +2279,7 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
       if ( hip_obj.obj.base != NULL && !hip_obj.clean )
          FLASH_Queue_read_async_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
       // Free the memory on the HIP for all the blocks.
-      FLASH_Queue_free_hip( hip_obj.buffer_hip );
+      FLASH_Queue_free_async_hip( hip_obj.buffer_hip );
    }
 
    return;

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Gemv_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -66,7 +66,9 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -151,7 +153,9 @@ FLA_Error FLA_Gemv_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Ob
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
+++ b/src/base/flamec/wrappers/blas/2/hip/FLA_Trsv_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -62,7 +62,9 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -125,7 +127,9 @@ FLA_Error FLA_Trsv_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Gemm_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -86,7 +86,9 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -100,7 +102,9 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
 
     dim_t elem_size = FLA_Obj_elem_size( B );
     size_t count = elem_size * ldim_B * n_B;
-    hipMalloc( &B_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &B_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, B, B_hip, B_mat_corr );
     B_mat = B_mat_corr;
   }
@@ -194,11 +198,15 @@ FLA_Error FLA_Gemm_external_hip( rocblas_handle handle, FLA_Trans transa, FLA_Tr
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
   if( conj_no_trans_b )
   {
-    hipFree( B_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, B_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Her2k_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -75,7 +75,9 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -165,7 +167,9 @@ FLA_Error FLA_Her2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( handle, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Herk_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -69,7 +69,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -155,7 +157,9 @@ FLA_Error FLA_Herk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syr2k_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -75,7 +75,9 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -165,7 +167,9 @@ FLA_Error FLA_Syr2k_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Tran
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Syrk_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -69,7 +69,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -155,7 +157,9 @@ FLA_Error FLA_Syrk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FLA_Trans
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trmm_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -63,7 +63,9 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -151,7 +153,9 @@ FLA_Error FLA_Trmm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
+++ b/src/base/flamec/wrappers/blas/3/hip/FLA_Trsm_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -63,7 +63,9 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * ldim_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -151,7 +153,9 @@ FLA_Error FLA_Trsm_external_hip( rocblas_handle handle, FLA_Side side, FLA_Uplo 
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Apply_Q_blk_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -71,7 +71,9 @@ FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FL
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * cs_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, A, A_hip, A_mat_corr );
     A_vecs = A_mat_corr;
   }
@@ -205,7 +207,9 @@ FLA_Error FLA_Apply_Q_blk_external_hip( rocblas_handle handle, FLA_Side side, FL
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( handle, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_U_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -76,7 +76,9 @@ FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side,
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * cs_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, A, A_hip, A_mat_corr );
     A_vecs = A_mat_corr;
   }
@@ -170,7 +172,9 @@ FLA_Error FLA_Bidiag_apply_U_external_hip( rocblas_handle handle, FLA_Side side,
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_apply_V_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -76,7 +76,9 @@ FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side,
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * cs_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_general_external_hip( handle, A, A_hip, A_mat_corr );
     A_vecs = A_mat_corr;
   }
@@ -170,7 +172,9 @@ FLA_Error FLA_Bidiag_apply_V_external_hip( rocblas_handle handle, FLA_Side side,
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_blk_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -38,8 +38,10 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 
   void* buff_d;
   void* buff_e;
-  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
-  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  hipMallocAsync( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n, stream );
+  hipMallocAsync( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n, stream );
 
   void* A_mat = NULL;
   void* tu_scals = NULL;
@@ -134,8 +136,8 @@ FLA_Error FLA_Bidiag_blk_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 
   }
 
-  hipFree( buff_d );
-  hipFree( buff_e );
+  hipFreeAsync( stream, buff_d );
+  hipFreeAsync( stream, buff_e );
 
   return info;
 }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Bidiag_unb_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -38,8 +38,10 @@ FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 
   void* buff_d;
   void* buff_e;
-  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
-  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n );
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  hipMallocAsync( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n, stream );
+  hipMallocAsync( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * min_m_n, stream );
 
   void* A_mat = NULL;
   void* tu_scals = NULL;
@@ -134,8 +136,8 @@ FLA_Error FLA_Bidiag_unb_external_hip( rocblas_handle handle, FLA_Obj A, void* A
 
   }
 
-  hipFree( buff_d );
-  hipFree( buff_e );
+  hipFreeAsync( stream, buff_d );
+  hipFreeAsync( stream, buff_e );
 
   return info;
 }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_apply_Q_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -67,7 +67,9 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
 
     dim_t elem_size = FLA_Obj_elem_size( A );
     size_t count = elem_size * cs_A * n_A;
-    hipMalloc( &A_mat_corr, count );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipMallocAsync( &A_mat_corr, count, stream );
     FLA_Copyconj_tri_external_hip( handle, uplo, A, A_hip, A_mat_corr );
     A_mat = A_mat_corr;
   }
@@ -157,7 +159,9 @@ FLA_Error FLA_Tridiag_apply_Q_external_hip( rocblas_handle handle, FLA_Side side
 
   if( conj_no_trans_a )
   {
-    hipFree( A_mat_corr );
+    hipStream_t stream;
+    rocblas_get_stream( handle, &stream );
+    hipFreeAsync( stream, A_mat_corr );
   }
 
   return FLA_SUCCESS;

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_blk_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -34,8 +34,10 @@ FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   void* buff_d;
   void* buff_e;
-  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A );
-  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ) );
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  hipMallocAsync( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A, stream );
+  hipMallocAsync( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ), stream );
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
@@ -120,8 +122,8 @@ FLA_Error FLA_Tridiag_blk_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   }
 
-  hipFree( buff_d );
-  hipFree( buff_e );
+  hipFreeAsync( stream, buff_d );
+  hipFreeAsync( stream, buff_e );
 
   return FLA_SUCCESS;
 }

--- a/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
+++ b/src/base/flamec/wrappers/lapack/hip/FLA_Tridiag_unb_external_hip.c
@@ -1,7 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
-    Copyright (C) 2022, Advanced Micro Devices, Inc.
+    Copyright (C) 2022-2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -34,8 +34,10 @@ FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   void* buff_d;
   void* buff_e;
-  hipMalloc( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A );
-  hipMalloc( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ) );
+  hipStream_t stream;
+  rocblas_get_stream( handle, &stream );
+  hipMallocAsync( &buff_d, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * n_A, stream );
+  hipMallocAsync( &buff_e, FLA_Obj_datatype_size ( FLA_Obj_datatype_proj_to_real( A ) ) * ( n_A - 1 ), stream );
 
   rocblas_fill blas_uplo = FLA_Param_map_flame_to_rocblas_uplo( uplo );
 
@@ -120,8 +122,8 @@ FLA_Error FLA_Tridiag_unb_external_hip( rocblas_handle handle, FLA_Uplo uplo, FL
 
   }
 
-  hipFree( buff_d );
-  hipFree( buff_e );
+  hipFreeAsync( stream, buff_d );
+  hipFreeAsync( stream, buff_e );
 
   return FLA_SUCCESS;
 }


### PR DESCRIPTION
Details:
- Change freeing of HIP device buffers of FLA_Obj to be async. Rename queue API to reflect this change.
- For HIP wrapper interfaces that allocate/free work buffers and do not use info allocations, change allocations and freeing to be async.