### PR TITLE
Introduce read/write locks as an option.

### DIFF
--- a/docs/libflame/50-dev-api.tex
+++ b/docs/libflame/50-dev-api.tex
@@ -141,6 +141,135 @@ may result in undefined behavior.
 \end{params}
 \end{flaspec}
 
+% --- FLA_RWLock_init() ----------------------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLA_RWLock_init( FLA_RWLock* lock_ptr );
+\end{verbatim}
+\purpose{
+Initialize the read/write lock structure pointed to by \flalockns.
+Upon successful return, the state of the lock becomes initialized and
+unlocked.
+}
+\notes{
+Attempting to initialize a lock that has already been initialized (and
+not yet released) may result in undefined behavior.
+}
+\begin{checks}
+\checkitem
+\lockptr may not be \fnullns.
+%\itemvsp
+%\checkitem
+%
+\end{checks}
+\begin{params}
+\parameter{\flalockp}{lock\_ptr}{A pointer to an \flalock structure.}
+\end{params}
+\end{flaspec}
+
+% --- FLA_RWLock_write_acquire() -------------------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLA_RWLock_write_acquire( FLA_RWLock* lock_ptr );
+\end{verbatim}
+\purpose{
+Attempt to acquire the write lock pointed to by \lockptrns.
+If the lock is unavailable (if its state is already locked), the call
+blocks and returns only upon successful acquisition of the lock.
+}
+\begin{checks}
+\checkitem
+\lockptr may not be \fnullns.
+%\itemvsp
+%\checkitem
+%
+\end{checks}
+\begin{params}
+\parameter{\flalockp}{lock\_ptr}{A pointer to an \flalock structure.}
+\end{params}
+\end{flaspec}
+
+% --- FLA_RWLock_read_acquire() -------------------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLA_RWLock_read_acquire( FLA_RWLock* lock_ptr );
+\end{verbatim}
+\purpose{
+Attempt to acquire the read lock pointed to by \lockptrns (if supported).
+If read-only functionality is not supported, will fall back to a regular/write
+lock acquire.
+If the lock is write locked by another thread, the call
+blocks and returns only upon successful acquisition of the read lock.
+If the lock is read locked by another thread, the call will suceed.
+}
+\begin{checks}
+\checkitem
+\lockptr may not be \fnullns.
+%\itemvsp
+%\checkitem
+%
+\end{checks}
+\begin{params}
+\parameter{\flalockp}{lock\_ptr}{A pointer to an \flalock structure.}
+\end{params}
+\end{flaspec}
+
+% --- FLA_RWLock_release() -------------------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLA_RWLock_release( FLA_RWLock* lock_ptr )
+\end{verbatim}
+\purpose{
+Release the lock associated with the structure pointed to by \flalockns.
+}
+\notes{
+Attempting to release a lock that is uninitialized or that has not yet
+been acquired may result in undefined behavior.
+}
+\begin{checks}
+\checkitem
+\lockptr may not be \fnullns.
+%\itemvsp
+%\checkitem
+%
+\end{checks}
+\begin{params}
+\parameter{\flalockp}{lock\_ptr}{A pointer to an \flalock structure.}
+\end{params}
+\end{flaspec}
+
+% --- FLA_RWLock_destroy() -------------------------------------------------------
+
+\begin{flaspec}
+\begin{verbatim}
+void FLA_RWLock_destroy( FLA_RWLock* lock_ptr );
+\end{verbatim}
+\purpose{
+Destroy the the lock structure pointed to by \flalockns.
+This causes all system resources associated with the lock that had been
+previously allocated by {\tt FLA\_Lock\_init()} to be freed.
+Upon returning, the state of the lock becomes uninitialized.
+}
+\notes{
+Attempting to destroy a lock that is currently in the locked state
+may result in undefined behavior.
+}
+\begin{checks}
+\checkitem
+\lockptr may not be \fnullns.
+%\itemvsp
+%\checkitem
+%
+\end{checks}
+\begin{params}
+\parameter{\flalockp}{lock\_ptr}{A pointer to an \flalock structure.}
+\end{params}
+\end{flaspec}
+
 
 
 

--- a/src/base/flamec/include/FLA_main_prototypes.h
+++ b/src/base/flamec/include/FLA_main_prototypes.h
@@ -169,7 +169,11 @@ void          FLA_Lock_init( FLA_Lock* fla_lock_ptr );
 void          FLA_Lock_destroy( FLA_Lock* fla_lock_ptr );
 void          FLA_Lock_acquire( FLA_Lock* fla_lock_ptr );
 void          FLA_Lock_release( FLA_Lock* fla_lock_ptr );
-
+void          FLA_RWLock_init( FLA_RWLock* fla_lock_ptr );
+void          FLA_RWLock_destroy( FLA_RWLock* fla_lock_ptr );
+void          FLA_RWLock_write_acquire( FLA_RWLock* fla_lock_ptr );
+void          FLA_RWLock_read_acquire( FLA_RWLock* fla_lock_ptr );
+void          FLA_RWLock_release( FLA_RWLock* fla_lock_ptr );
 
 
 // -----------------------------------------------------------------------------

--- a/src/base/flamec/include/FLA_type_defs.h
+++ b/src/base/flamec/include/FLA_type_defs.h
@@ -96,6 +96,7 @@ typedef union
 // --- FLAME object definitions -----------------------------------------------
 
 typedef struct FLA_Lock_s     FLA_Lock;
+typedef struct FLA_RWLock_s   FLA_RWLock;
 
 //#ifdef FLA_ENABLE_MULTITHREADING
 struct FLA_Lock_s
@@ -105,6 +106,15 @@ struct FLA_Lock_s
   omp_lock_t       lock;
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
   pthread_mutex_t  lock;
+#endif
+};
+struct FLA_RWLock_s
+{
+  // Implementation-specific lock object
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_lock_t       lock;
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_t lock;
 #endif
 };
 //#endif

--- a/src/base/flamec/main/FLA_Lock.c
+++ b/src/base/flamec/main/FLA_Lock.c
@@ -85,5 +85,79 @@ void FLA_Lock_destroy( FLA_Lock* fla_lock_ptr )
 }
 
 
+void FLA_RWLock_init( FLA_RWLock* fla_lock_ptr )
+/*----------------------------------------------------------------------------
+
+   FLA_Lock_init
+
+----------------------------------------------------------------------------*/
+{
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_init_lock( &(fla_lock_ptr->lock) );
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_init( &(fla_lock_ptr->lock), NULL );
+#endif
+}
+
+
+void FLA_RWLock_write_acquire( FLA_RWLock* fla_lock_ptr )
+/*----------------------------------------------------------------------------
+
+   FLA_Lock_acquire
+
+----------------------------------------------------------------------------*/
+{
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_set_lock( &(fla_lock_ptr->lock) );
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_wrlock( &(fla_lock_ptr->lock) );
+#endif
+}
+
+
+void FLA_RWLock_read_acquire( FLA_RWLock* fla_lock_ptr )
+/*----------------------------------------------------------------------------
+
+   FLA_Lock_read_acquire
+
+----------------------------------------------------------------------------*/
+{
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_set_lock( &(fla_lock_ptr->lock) );
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_rdlock( &(fla_lock_ptr->lock) );
+#endif
+}
+
+
+void FLA_RWLock_release( FLA_RWLock* fla_lock_ptr )
+/*----------------------------------------------------------------------------
+
+   FLA_Lock_release
+
+----------------------------------------------------------------------------*/
+{
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_unset_lock( &(fla_lock_ptr->lock) );
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_unlock( &(fla_lock_ptr->lock) );
+#endif
+}
+
+
+void FLA_RWLock_destroy( FLA_RWLock* fla_lock_ptr )
+/*----------------------------------------------------------------------------
+
+   FLA_Lock_destroy
+
+----------------------------------------------------------------------------*/
+{
+#if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
+  omp_destroy_lock( &(fla_lock_ptr->lock) );
+#elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
+  pthread_rwlock_destroy( &(fla_lock_ptr->lock) );
+#endif
+}
+
 #endif // FLA_ENABLE_MULTITHREADING
 


### PR DESCRIPTION
Details:
- RW locks allow multiple readers to acquire a lock while retaining writer exclusivity.
- Introduce a FLA_RWLock struct.
- If pthread is used, use pthread's RW lock under the hood. If OpenMP is used fall back to a mutex (no multi-reader functinality).
- Use the new RW lock for the HIP FLASH backend to allow inspecting block status in read-mode from multiple threads (as there's an imbalance readers to writers typically).