### PR TITLE
Prepare APIs for non-default streams

### DIFF
--- a/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
+++ b/src/base/flamec/supermatrix/hip/include/FLASH_Queue_hip.h
@@ -35,11 +35,12 @@ void           FLASH_Queue_set_hip_num_blocks( dim_t n_blocks );
 dim_t          FLASH_Queue_get_hip_num_blocks( void );
 
 FLA_Error      FLASH_Queue_bind_hip( int thread );
-FLA_Error      FLASH_Queue_alloc_hip( dim_t size, FLA_Datatype datatype, void** buffer_hip );
-FLA_Error      FLASH_Queue_free_async_hip( void* buffer_hip );
-FLA_Error      FLASH_Queue_write_hip( FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_alloc_async_hip( int thread, dim_t size, FLA_Datatype datatype, void** buffer_hip );
+FLA_Error      FLASH_Queue_free_async_hip( int thread, void* buffer_hip );
+FLA_Error      FLASH_Queue_write_async_hip( int thread, FLA_Obj obj, void* buffer_hip );
 FLA_Error      FLASH_Queue_read_hip( int thread, FLA_Obj obj, void* buffer_hip );
 FLA_Error      FLASH_Queue_read_async_hip( int thread, FLA_Obj obj, void* buffer_hip );
+FLA_Error      FLASH_Queue_sync_stream_hip( int thread );
 FLA_Error      FLASH_Queue_sync_device_hip( int device );
 FLA_Error      FLASH_Queue_sync_hip( );
 


### PR DESCRIPTION
Details:
* instead of using the default null stream in HIP queue functions, get the stream from the rocblas_handle associated with the thread
* add a stream sync function
* rename the HIP write API to write_async to correctly signal intent
* change the device allocation to be asynchronous (and rename API)
* write something unique into the buffer_hip pointer in the managed memory case to ensure comparisons are correct