### PR TITLE
Auto-disable HIP for small problems in the lapack2flash wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -862,9 +862,11 @@ cleanobj:
 ifeq ($(IS_CONFIGURED),yes)
 ifeq ($(ENABLE_VERBOSE),yes)
 	- $(FIND) $(BASE_OBJ_PATH) -name "*.o" | $(XARGS) $(RM_F)
+	- $(FIND) $(BASE_OBJ_PATH) -name "*.mod" | $(XARGS) $(RM_F)
 else
 	@echo "Removing object files from $(BASE_OBJ_PATH)"
 	@$(FIND) $(BASE_OBJ_PATH) -name "*.o" | $(XARGS) $(RM_F)
+	@$(FIND) $(BASE_OBJ_PATH) -name "*.mod" | $(XARGS) $(RM_F)
 endif
 endif
 
@@ -873,10 +875,16 @@ ifeq ($(IS_CONFIGURED),yes)
 ifeq ($(ENABLE_VERBOSE),yes)
 	- $(RM_F) $(LIBFLAME_A_PATH)
 	- $(RM_F) $(LIBFLAME_SO_PATH)
+	- $(RM_F) $(AR_OBJ_LIST_FILE)
+	- $(RM_F) $(AR_OBJ_LIST_FILE).atmp
+	- $(RM_F) $(AR_OBJ_LIST_FILE).sotmp
 else
 	@echo "Removing libraries from $(BASE_LIB_PATH)"
 	@$(RM_F) $(LIBFLAME_A_PATH)
 	@$(RM_F) $(LIBFLAME_SO_PATH)
+	@$(RM_F) $(AR_OBJ_LIST_FILE)
+	@$(RM_F) $(AR_OBJ_LIST_FILE).atmp
+	@$(RM_F) $(AR_OBJ_LIST_FILE).sotmp
 endif
 endif
 
@@ -898,9 +906,6 @@ endif
 distclean: cleanmk cleanh cleanobj cleanlib cleanhack
 ifeq ($(IS_CONFIGURED),yes)
 ifeq ($(ENABLE_VERBOSE),yes)
-	- $(RM_F) $(AR_OBJ_LIST_FILE)
-	- $(RM_F) $(AR_OBJ_LIST_FILE).atmp
-	- $(RM_F) $(AR_OBJ_LIST_FILE).sotmp
 	- $(RM_RF) $(CONFIG_DIR)
 	- $(RM_RF) $(OBJ_DIR)
 	- $(RM_RF) $(LIB_DIR)
@@ -912,8 +917,6 @@ ifeq ($(ENABLE_VERBOSE),yes)
 	- $(RM_RF) config.sys_type
 	- $(RM_RF) config.dist_path
 else
-	@echo "Removing $(AR_OBJ_LIST_FILE)"
-	@$(RM_F) $(AR_OBJ_LIST_FILE)
 	@echo "Removing $(CONFIG_DIR)"
 	@$(RM_RF) $(CONFIG_DIR)
 	@echo "Removing $(OBJ_DIR)"

--- a/src/base/flamec/include/FLAME.h
+++ b/src/base/flamec/include/FLAME.h
@@ -95,6 +95,9 @@ extern "C" {
   // Include prototypes for LAPACK routines.
   //#include "FLA_lapack_f77_macro_defs.h"
 
+  // Include prototypes for FLASH get/sets.
+  #include "FLASH_get_set_controls.h"
+
 // End extern "C" construct block.
 #ifdef __cplusplus
 }

--- a/src/map/common/lapacksrc/scripts/regen-files.sh
+++ b/src/map/common/lapacksrc/scripts/regen-files.sh
@@ -28,14 +28,12 @@ usage() {
 }
 
 clean() {
-
     rm -f $script_dir/../netlib/._*
     rm -f $script_dir/../netlib/*.{f,F,f90,F90}
     rm -f $script_dir/../netlib/*~
     rm -rf $script_dir/../netlib/lapack-*/
     rm -f $script_dir/../fortran/*.{f,F,f90,F90}
     rm -f $script_dir/../fortran/depen_mods/*.{f,F,f90,F90}
-
 }
 
 ## Pass an install type and a tar if needed
@@ -53,7 +51,6 @@ fi
 
 if [[ "$tar_file" == "" && "$install_type" != "cleanup" ]]
 then
-
     ## Try to auto select a tar if the user doesn't provide one
     num_of_tars=$(ls -1q $script_dir/../netlib/*.{tar,tgz,tar.gz} 2> /dev/null | wc -l)
 
@@ -68,17 +65,15 @@ then
         usage
         exit
     fi
-
 fi
 
 if [[ "$install_type" == build || "$install_type" == build_test || "$install_type" == other_installs ]]
 then
-
-    ## Make sure there are no old files
-    clean
-
     if [[ "$install_type" == build ]]
     then
+        ## Make sure there are no old files
+        clean
+
         ## Untar
         ## It was observed that the tars had only the src files
         ## While the tgz/tar.gz had the full netlibs. However, this
@@ -113,7 +108,6 @@ then
         ## Disable xblas-related code so shared libraries link properly.
         cd $script_dir
         ./disable_xblas.sh
-
     elif [[ "$install_type" == build_test ]]
     then
         ## This section lets a user update netlibs-test and  

--- a/src/map/lapack2flash/FLASH_get_set_controls.c
+++ b/src/map/lapack2flash/FLASH_get_set_controls.c
@@ -1,0 +1,102 @@
+/*
+
+    Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#include "FLAME.h"
+
+#ifdef FLA_ENABLE_LAPACK2FLASH // Start lapack2flash
+
+static dim_t        lapack2flash_blocksize = 1024;
+static unsigned int lapack2flash_n_threads = 1;
+static dim_t        lapack2flash_depth = 1;
+static unsigned int lapack2flash_tiles = 16;
+
+/*---------------------Get/Set Helper---------------------*/
+
+FLA_Error FLASH_set_preferred_blocksize( dim_t blocksize )
+{
+    if ( blocksize != 0 )
+    {
+        lapack2flash_blocksize = blocksize;
+
+        return FLA_SUCCESS;
+    }
+    else
+    {
+        return FLA_FAILURE;
+    }
+}
+
+dim_t FLASH_get_preferred_blocksize( void )
+{
+    return lapack2flash_blocksize;
+}
+
+FLA_Error FLASH_set_n_preferred_threads( unsigned int threads )
+{
+    if ( threads != 0 )
+    {
+        lapack2flash_n_threads = threads;
+
+        #ifdef FLA_ENABLE_HIP
+            int device_count = 1;
+            FLASH_Queue_available_devices_hip( &device_count );
+
+            // Pass number of threads unless it's more than available devices
+            FLASH_Queue_set_num_threads( min( threads, device_count) );
+        #else
+            FLASH_Queue_set_num_threads( threads );
+        #endif
+
+        return FLA_SUCCESS;
+    }
+    else
+    {
+        return FLA_FAILURE;
+    }
+}
+
+unsigned int FLASH_get_n_preferred_threads( void )
+{
+    // Returning the number of preferred threads, not actual number.
+    return lapack2flash_n_threads;
+}
+
+FLA_Error FLASH_set_depth( dim_t depth )
+{
+    if ( depth != 0 )
+    {
+        lapack2flash_depth = depth;
+
+        return FLA_SUCCESS;
+    }
+    else
+    {
+        return FLA_FAILURE;
+    }
+}
+
+dim_t FLASH_get_depth( void )
+{
+    return lapack2flash_depth;
+}
+
+FLA_Error FLASH_set_tile_offload( unsigned int tiles )
+{
+    lapack2flash_tiles = tiles;
+
+    return FLA_SUCCESS;
+}
+
+unsigned int FLASH_get_tile_offload( void )
+{
+    return lapack2flash_tiles;
+}
+
+#endif // End lapack2flash

--- a/src/map/lapack2flash/FLASH_get_set_controls.h
+++ b/src/map/lapack2flash/FLASH_get_set_controls.h
@@ -1,0 +1,27 @@
+/*
+
+    Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+    This file is part of libflame and is available under the 3-Clause
+    BSD license, which can be found in the LICENSE file at the top-level
+    directory, or at http://opensource.org/licenses/BSD-3-Clause
+
+*/
+
+#ifndef FLASH_GET_SET_CONTROLS_H
+#define FLASH_GET_SET_CONTROLS_H
+
+#ifdef FLA_ENABLE_LAPACK2FLASH // Start lapack2flash
+
+FLA_Error      FLASH_set_preferred_blocksize( dim_t blocksize );
+dim_t          FLASH_get_preferred_blocksize( void );
+FLA_Error      FLASH_set_n_preferred_threads( unsigned int threads );
+unsigned int   FLASH_get_n_preferred_threads( void );
+FLA_Error      FLASH_set_depth( dim_t depth );
+dim_t          FLASH_get_depth( void );
+FLA_Error      FLASH_set_tile_offload( unsigned int tiles );
+unsigned int   FLASH_get_tile_offload( void );
+
+#endif // End lapack2flash
+
+#endif // End header

--- a/src/map/lapack2flash/FLASH_lapack2flash_util_defs.h
+++ b/src/map/lapack2flash/FLASH_lapack2flash_util_defs.h
@@ -85,11 +85,7 @@ extern int FLAME_invert_ztau( FLA_Obj t );
 
 extern int FLAME_QR_piv_preorder( FLA_Obj A, int *jpiv_lapack, int *jpiv_fla );
 
-FLA_Error      FLASH_set_preferred_blocksize( dim_t blocksize );
-dim_t          FLASH_get_preferred_blocksize( void );
-FLA_Error      FLASH_set_n_preferred_threads( unsigned int threads );
-unsigned int   FLASH_get_n_preferred_threads( void );
-FLA_Error      FLASH_set_depth( dim_t depth );
-dim_t          FLASH_get_depth( void );
+FLA_Bool FLASH_Check_offload_to_gpu( dim_t blocksize, int m, int n, unsigned int crossover );
+void FLASH_Toggle_gpu_offload( FLA_Bool toggle );
 
 #endif

--- a/src/map/lapack2flash/FLASH_lauum.c
+++ b/src/map/lapack2flash/FLASH_lauum.c
@@ -42,6 +42,9 @@
   dim_t        blocksize = min( FLASH_get_preferred_blocksize(),\
                                 *ldim_A );                      \
                                                                 \
+  FLA_Bool toggle = FLASH_Check_offload_to_gpu( blocksize, *n,  \
+                          *n, FLASH_get_tile_offload() );       \
+                                                                \
   FLA_Init_safe( &init_result );                                \
                                                                 \
   FLA_Param_map_netlib_to_flame_uplo( uplo, &uplo_fla );        \
@@ -59,6 +62,8 @@
   FLASH_Obj_free_without_buffer( &A );                          \
                                                                 \
   FLA_Finalize_safe( init_result );                             \
+                                                                \
+  FLASH_Toggle_gpu_offload( toggle );                           \
                                                                 \
   *info = 0;                                                    \
                                                                 \

--- a/src/map/lapack2flash/FLASH_potrf.c
+++ b/src/map/lapack2flash/FLASH_potrf.c
@@ -45,6 +45,9 @@
   dim_t        blocksize = min( FLASH_get_preferred_blocksize(),\
                                 *ldim_A );                      \
                                                                 \
+  FLA_Bool toggle = FLASH_Check_offload_to_gpu( blocksize, *n,  \
+                          *n, FLASH_get_tile_offload() );       \
+                                                                \
   FLA_Init_safe( &init_result );                                \
   FLA_Param_map_netlib_to_flame_uplo( uplo, &uplo_fla );        \
                                                                 \
@@ -59,6 +62,8 @@
   e_val = FLASH_Chol( uplo_fla, A );                            \
                                                                 \
   FLASH_Obj_free_without_buffer( &A );                          \
+                                                                \
+  FLASH_Toggle_gpu_offload( toggle );                           \
                                                                 \
   FLA_Finalize_safe( init_result );                             \
                                                                 \

--- a/src/map/lapack2flash/FLASH_potri.c
+++ b/src/map/lapack2flash/FLASH_potri.c
@@ -39,6 +39,9 @@
   dim_t        blocksize = min( FLASH_get_preferred_blocksize(),\
                                 *ldim_A );                      \
                                                                 \
+  FLA_Bool toggle = FLASH_Check_offload_to_gpu( blocksize, *n,  \
+                          *n, FLASH_get_tile_offload() );       \
+                                                                \
   FLA_Init_safe( &init_result );                                \
   FLA_Param_map_netlib_to_flame_uplo( uplo, &uplo_fla );        \
                                                                 \
@@ -60,6 +63,8 @@
   FLASH_Obj_free_without_buffer( &A );                          \
                                                                 \
   FLA_Finalize_safe( init_result );                             \
+                                                                \
+  FLASH_Toggle_gpu_offload( toggle );                           \
                                                                 \
   return 0;
 

--- a/src/map/lapack2flash/FLASH_trsyl.c
+++ b/src/map/lapack2flash/FLASH_trsyl.c
@@ -72,6 +72,10 @@
   else             sgn_fla = FLA_MINUS_ONE;                     \
                                                                 \
   blocksize = ( FLASH_get_preferred_blocksize(), *ldim_A );     \
+                                                                \
+  FLA_Bool toggle = FLASH_Check_offload_to_gpu( blocksize, *m,  \
+                          *n, FLASH_get_tile_offload() );       \
+                                                                \
   FLASH_Obj_create_without_buffer( datatype,                    \
                                    *m,                          \
                                    *m,                          \
@@ -121,6 +125,8 @@
   FLASH_Obj_free_without_buffer( &scale_fla );                  \
                                                                 \
   FLA_Finalize_safe( init_result );                             \
+                                                                \
+  FLASH_Toggle_gpu_offload( toggle );                           \
                                                                 \
   if ( e_val != FLA_SUCCESS ) *info = 1;                        \
   else                        *info = 0;                        \

--- a/src/map/lapack2flash/FLASH_trtri.c
+++ b/src/map/lapack2flash/FLASH_trtri.c
@@ -50,6 +50,9 @@
   dim_t        blocksize = min( FLASH_get_preferred_blocksize(),\
                                 *ldim_A );                      \
                                                                 \
+  FLA_Bool toggle = FLASH_Check_offload_to_gpu( blocksize, *n,  \
+                          *n, FLASH_get_tile_offload() );       \
+                                                                \
   FLA_Init_safe( &init_result );                                \
                                                                 \
   FLA_Param_map_netlib_to_flame_uplo( uplo, &uplo_fla );        \
@@ -68,6 +71,8 @@
   FLASH_Obj_free_without_buffer( &A );                          \
                                                                 \
   FLA_Finalize_safe( init_result );                             \
+                                                                \
+  FLASH_Toggle_gpu_offload( toggle );                           \
                                                                 \
   *info = 0;                                                    \
                                                                 \


### PR DESCRIPTION
Details:
- instead of using the HIP queue independent of problem size, check if blocked size is above or below a crossover point. If it is below, disable the HIP queue prior to running the problem and re-enable it afterwards.
- while there, fix a few small build issues and add the lapack2flash header to FLAME.h