### PR TITLE
Add LTO option

### DIFF
--- a/build/FLA_config.h.in
+++ b/build/FLA_config.h.in
@@ -74,6 +74,9 @@
    of lapack with lapack2flame or lapack2flash. */
 #undef FLA_ENABLE_LEGACY_LAPACK
 
+/* Determines whether LTO-specific blocks of code should be compiled. */
+#undef FLA_ENABLE_LTO
+
 /* Determines whether memory is aligned to user-requested boundaries. */
 #undef FLA_ENABLE_MEMORY_ALIGNMENT
 

--- a/build/ac-macros/fla_check_enable_lto.m4
+++ b/build/ac-macros/fla_check_enable_lto.m4
@@ -1,0 +1,63 @@
+AC_DEFUN([FLA_CHECK_ENABLE_LTO],
+[
+	dnl Tell the user we're checking whether to enable the option.
+	AC_MSG_CHECKING([whether user requested to enable LTO])
+	
+	dnl Determine whether the user gave the --enable-<option> or
+	dnl --disable-<option>. If so, then run the first snippet of code;
+	dnl otherwise, run the second code block.
+	AC_ARG_ENABLE([lto],
+	              AS_HELP_STRING([--enable-lto],[Enable LTO for compilation. (Disabled by default.)]),
+	[
+		dnl If any form of the option is given, handle each case.
+		if test "$enableval" = "no" ; then
+
+			dnl User provided --enable-<option>=no or --disable-<option>.
+			fla_enable_lto=no
+
+		elif test "$enableval" = "yes" ; then
+
+			dnl User provided --enable-<option>=yes or --enable-<option>.
+			fla_enable_lto=yes
+		else
+
+			dnl We don't need an else branch because the configure script
+			dnl should detect whether the user provided an unexpected argument
+			dnl with the option.
+			AC_MSG_ERROR([[Reached unreachable branch in FLA_CHECK_ENABLE_LTO!]])
+		fi
+	],
+	[
+		dnl User did not specify whether to enable or disable the option.
+		dnl Default behavior is to disable the option.
+		fla_enable_lto=no
+	]
+	)
+
+	dnl Now act according to whether the option was requested.
+	if   test "$fla_enable_lto" = "yes" ; then
+		
+		dnl Output the result.
+		AC_MSG_RESULT([yes])
+		
+		dnl Define the macro.
+		AC_DEFINE(FLA_ENABLE_LTO,1,
+		          [Determines whether LTO-specific blocks of code should be compiled.])
+		
+	elif test "$fla_enable_lto" = "no" ; then
+		
+		dnl Output the result.
+		AC_MSG_RESULT([no])
+		
+	else
+
+		dnl Only "yes" and "no" are accepted, so this block is empty.
+		AC_MSG_ERROR([[Reached unreachable branch in FLA_CHECK_ENABLE_LTO!]])
+
+	fi
+	
+	dnl Substitute the output variable.
+	AC_SUBST(fla_enable_lto)
+
+])
+

--- a/build/config.mk.in
+++ b/build/config.mk.in
@@ -177,5 +177,11 @@ LDFLAGS      := -L/opt/rocm/lib -lrocsolver -lrocblas -lamdhip64 -lhsa-runtime64
 endif
 
 
+# --- Enable LTO if requested ---
+ifeq (@fla_enable_lto@, yes)
+CFLAGS       := -flto -fno-semantic-interposition $(CFLAGS)
+LDFLAGS      := -flto -fno-semantic-interposition $(LDFLAGS)
+endif
+
 # end of ifndef CONFIG_MK_INCLUDED conditional block
 endif

--- a/build/post-configure.sh.in
+++ b/build/post-configure.sh.in
@@ -108,6 +108,8 @@ echo "   C compiler debug flags....................... : @fla_c_debug_flags@"
 echo "Enable compiler profiling symbols............... : @fla_enable_compiler_profiling@"
 echo "   C compiler profiling flags................... : @fla_c_prof_flags@"
 
+echo "Enable LTO...................................... : @fla_enable_lto@"
+
 echo ""
 echo "User-specified CFLAGS (prepended)............... : @fla_userdef_cflags@"
 

--- a/configure
+++ b/configure
@@ -648,6 +648,7 @@ fla_enable_blis_use_of_fla_malloc
 fla_enable_memory_leak_counter
 fla_internal_error_checking_level
 fla_enable_internal_error_checking
+fla_enable_lto
 fla_enable_compiler_profiling
 fla_c_prof_flags
 fla_enable_compiler_debug
@@ -794,6 +795,7 @@ enable_optimizations
 enable_warnings
 enable_debug
 enable_profiling
+enable_lto
 enable_internal_error_checking
 enable_memory_leak_counter
 enable_blis_use_of_fla_malloc
@@ -1588,6 +1590,7 @@ Optional Features:
                           default.)
   --enable-profiling      Use the appropriate profiling flag (usually -pg)
                           when compiling C source code. (Disabled by default.)
+  --enable-lto            Enable LTO for compilation. (Disabled by default.)
   --enable-internal-error-checking=level
                           Enable various internal runtime checks of function
                           parameters and object properties to prevent
@@ -7867,6 +7870,57 @@ $as_echo "$fla_c_prof_flags" >&6; }
 
 
 
+
+
+
+
+
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether user requested to enable LTO" >&5
+$as_echo_n "checking whether user requested to enable LTO... " >&6; }
+
+				# Check whether --enable-lto was given.
+if test "${enable_lto+set}" = set; then :
+  enableval=$enable_lto;
+				if test "$enableval" = "no" ; then
+
+						fla_enable_lto=no
+
+		elif test "$enableval" = "yes" ; then
+
+						fla_enable_lto=yes
+		else
+
+												as_fn_error $? "Reached unreachable branch in FLA_CHECK_ENABLE_LTO!" "$LINENO" 5
+		fi
+
+else
+
+						fla_enable_lto=no
+
+
+fi
+
+
+		if   test "$fla_enable_lto" = "yes" ; then
+
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+
+$as_echo "#define FLA_ENABLE_LTO 1" >>confdefs.h
+
+
+	elif test "$fla_enable_lto" = "no" ; then
+
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+	else
+
+				as_fn_error $? "Reached unreachable branch in FLA_CHECK_ENABLE_LTO!" "$LINENO" 5
+
+	fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -508,6 +508,9 @@ FLA_CHECK_ENABLE_DEBUG
 dnl Set the appropriate compiler profiling flags, if requested.
 FLA_CHECK_ENABLE_PROFILING
 
+dnl Set the appropriate compiler flags for LTO, if requested.
+FLA_CHECK_ENABLE_LTO
+
 dnl Observe whether we're going to perform internal error checking.
 FLA_CHECK_ENABLE_INTERNAL_ERROR_CHECKING
 


### PR DESCRIPTION
Details:
- add a configure-time option to --enable-lto (off by default)
- adds -flto and -fno-semantic-interposition to CFLAGS and LDFLAGS
- add a FLA_ENABLE_LTO macro