### PR TITLE
Optimize locks

### DIFF
--- a/src/base/flamec/main/FLA_Lock.c
+++ b/src/base/flamec/main/FLA_Lock.c
@@ -32,6 +32,11 @@ void FLA_Lock_init( FLA_Lock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL )
+  {
+     fprintf( stderr, "Lock pointer NULL in init.\n" );
+     return;
+  }
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_init_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -47,6 +52,7 @@ void FLA_Lock_acquire( FLA_Lock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_set_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -62,6 +68,7 @@ void FLA_Lock_release( FLA_Lock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_unset_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -77,6 +84,7 @@ void FLA_Lock_destroy( FLA_Lock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_destroy_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -92,6 +100,11 @@ void FLA_RWLock_init( FLA_RWLock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL )
+  {
+     fprintf( stderr, "RWLock pointer NULL in init.\n" );
+     return;
+  }
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_init_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -107,6 +120,7 @@ void FLA_RWLock_write_acquire( FLA_RWLock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_set_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -122,6 +136,7 @@ void FLA_RWLock_read_acquire( FLA_RWLock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_set_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -137,6 +152,7 @@ void FLA_RWLock_release( FLA_RWLock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_unset_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS
@@ -152,6 +168,7 @@ void FLA_RWLock_destroy( FLA_RWLock* fla_lock_ptr )
 
 ----------------------------------------------------------------------------*/
 {
+  if ( fla_lock_ptr == NULL ) return;
 #if   FLA_MULTITHREADING_MODEL == FLA_OPENMP
   omp_destroy_lock( &(fla_lock_ptr->lock) );
 #elif FLA_MULTITHREADING_MODEL == FLA_PTHREADS

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -174,10 +174,10 @@ void FLASH_Queue_exec( void )
    dim_t        block_size = FLASH_Queue_get_block_size();
    double       dtime;
 
-   FLA_Lock*    run_lock;
-   FLA_Lock*    dep_lock;
-   FLA_Lock*    war_lock;
-   FLA_Lock*    cac_lock;
+   FLA_Lock*    run_lock = NULL;
+   FLA_Lock*    dep_lock = NULL;
+   FLA_Lock*    war_lock = NULL;
+   FLA_Lock*    cac_lock = NULL;
 
    FLA_Obj*     cache;
    FLA_Obj*     prefetch;
@@ -195,7 +195,7 @@ void FLASH_Queue_exec( void )
 
 #ifdef FLA_ENABLE_HIP
 #ifdef FLA_ENABLE_MULTITHREADING
-   FLA_RWLock*    hip_lock;
+   FLA_RWLock*    hip_lock = NULL;
 #endif
    FLA_Obj_hip* hip;
    FLA_Obj_hip* victim;
@@ -272,37 +272,40 @@ void FLASH_Queue_exec( void )
    args.n_caches = n_caches;
 
 #ifdef FLA_ENABLE_MULTITHREADING
-   // Allocate memory for array of locks.
-   run_lock = ( FLA_Lock* ) FLA_malloc( n_queues  * sizeof( FLA_Lock ) );
-   dep_lock = ( FLA_Lock* ) FLA_malloc( n_threads * sizeof( FLA_Lock ) );
-   war_lock = ( FLA_Lock* ) FLA_malloc( n_threads * sizeof( FLA_Lock ) );
-   cac_lock = ( FLA_Lock* ) FLA_malloc( n_caches  * sizeof( FLA_Lock ) );
-
-   args.run_lock = run_lock;
-   args.dep_lock = dep_lock;
-   args.war_lock = war_lock;
-   args.cac_lock = cac_lock;
-
    // Initialize the all lock.
    FLA_Lock_init( &(args.all_lock) );
-   
-   // Initialize the run lock for thread i.
-   for ( i = 0; i < n_queues; i++ )
-   {
-      FLA_Lock_init( &(args.run_lock[i]) );
-   }
 
-   // Initialize the dep and war locks for thread i.
-   for ( i = 0; i < n_threads; i++ )
+   // If needed: allocate memory for array of locks and initialize.
+   if ( n_threads > 1 || n_queues > 1 || n_caches > 1 )
    {
-      FLA_Lock_init( &(args.dep_lock[i]) );
-      FLA_Lock_init( &(args.war_lock[i]) );
+      run_lock = ( FLA_Lock* ) FLA_malloc( n_queues  * sizeof( FLA_Lock ) );
+      args.run_lock = run_lock;
+      for ( i = 0; i < n_queues; i++ )
+      {
+         FLA_Lock_init( &(args.run_lock[i]) );
+      }
+      dep_lock = ( FLA_Lock* ) FLA_malloc( n_threads * sizeof( FLA_Lock ) );
+      war_lock = ( FLA_Lock* ) FLA_malloc( n_threads * sizeof( FLA_Lock ) );
+      args.dep_lock = dep_lock;
+      args.war_lock = war_lock;
+      for ( i = 0; i < n_threads; i++ )
+      {
+         FLA_Lock_init( &(args.dep_lock[i]) );
+         FLA_Lock_init( &(args.war_lock[i]) );
+      }
+      cac_lock = ( FLA_Lock* ) FLA_malloc( n_caches  * sizeof( FLA_Lock ) );
+      args.cac_lock = cac_lock;
+      for ( i = 0; i < n_caches; i++ )
+      {
+         FLA_Lock_init( &(args.cac_lock[i]) );
+      }
    }
-
-   // Initialize the cac locks for each cache.
-   for ( i = 0; i < n_caches; i++ )
+   else
    {
-      FLA_Lock_init( &(args.cac_lock[i]) );
+      args.run_lock = NULL;
+      args.dep_lock = NULL;
+      args.war_lock = NULL;
+      args.cac_lock = NULL;
    }
 #endif
 
@@ -372,12 +375,16 @@ void FLASH_Queue_exec( void )
 
 #ifdef FLA_ENABLE_HIP
 #ifdef FLA_ENABLE_MULTITHREADING
-   // Allocate and initialize the hip locks.
-   hip_lock = ( FLA_RWLock* ) FLA_malloc( n_threads * sizeof( FLA_RWLock ) );
-   args.hip_lock = hip_lock;
-
-   for ( i = 0; i < n_threads; i++ )
-      FLA_RWLock_init( &(args.hip_lock[i]) );
+   if ( n_threads > 1 )
+   {
+      // Allocate and initialize the hip locks.
+      hip_lock = ( FLA_RWLock* ) FLA_malloc( n_threads * sizeof( FLA_RWLock ) );
+      args.hip_lock = hip_lock;
+      for ( i = 0; i < n_threads; i++ )
+         FLA_RWLock_init( &(args.hip_lock[i]) );
+   }
+   else
+      args.hip_lock = NULL;
 #endif
    // Allocate and initialize HIP software cache.
    hip = ( FLA_Obj_hip* ) FLA_malloc( hip_n_blocks * n_threads * sizeof( FLA_Obj_hip ) );
@@ -444,10 +451,10 @@ void FLASH_Queue_exec( void )
    }
 
    // Deallocate memory.
-   FLA_free( run_lock );
-   FLA_free( dep_lock );
-   FLA_free( war_lock );
-   FLA_free( cac_lock );
+   if ( run_lock != NULL ) FLA_free( run_lock );
+   if ( dep_lock != NULL ) FLA_free( dep_lock );
+   if ( war_lock != NULL ) FLA_free( war_lock );
+   if ( cac_lock != NULL ) FLA_free( cac_lock );
 #endif
 
    FLA_free( cache );
@@ -469,7 +476,7 @@ void FLASH_Queue_exec( void )
 #ifdef FLA_ENABLE_MULTITHREADING
    for ( i = 0; i < n_threads; i++ )
       FLA_RWLock_destroy( &(args.hip_lock[i]) );
-   FLA_free( hip_lock );
+   if ( hip_lock != NULL ) FLA_free( hip_lock );
 #endif
    FLA_free( hip );
    FLA_free( victim );


### PR DESCRIPTION
Details:
- target the single thread, single queue, single cache case (present in typical HIP offloading)
- do not allocate or initialize the locks - set them to NULL instead
- add a short circuit in the lock wrappers to return on NULL'd lock pointers
- add a warning if a NULL'd lock pointer is supposed to be initialized
- turn the all_lock into a heap allocated pointer