### PR TITLE
Improve HIP locking in FLASH

### DIFF
--- a/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
+++ b/src/base/flamec/supermatrix/hip/main/FLASH_Queue_hip.c
@@ -21,7 +21,7 @@
 
 
 static FLA_Bool flash_queue_enabled_hip  = FALSE;
-static FLA_Bool flash_malloc_managed_hip = FALSE;
+static FLA_Bool flash_malloc_managed_hip = TRUE;
 static dim_t    flash_queue_hip_n_blocks = 128;
 static rocblas_handle* handles;
 

--- a/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
+++ b/src/base/flamec/supermatrix/main/FLASH_Queue_exec.c
@@ -1,6 +1,7 @@
 /*
 
     Copyright (C) 2014, The University of Texas at Austin
+    Copyright (C) 2023, Advanced Micro Devices, Inc.
 
     This file is part of libflame and is available under the 3-Clause
     BSD license, which can be found in the LICENSE file at the top-level
@@ -142,12 +143,6 @@ typedef struct FLASH_Queue_variables
    // LRU software cache of HIP memory.
    FLA_Obj_hip* hip;
 
-   // Storing the block being evicted.
-   FLA_Obj_hip* victim;
-
-   // Temporary storage for logging blocks on the accelerator.
-   FLA_Obj_hip* hip_log;
-
    // The size of each block to allocate on the accelerator.
    dim_t        block_size;
 
@@ -198,8 +193,6 @@ void FLASH_Queue_exec( void )
    FLA_RWLock*    hip_lock;
 #endif
    FLA_Obj_hip* hip;
-   FLA_Obj_hip* victim;
-   FLA_Obj_hip* hip_log;
    dim_t        hip_n_blocks = FLASH_Queue_get_hip_num_blocks();
 #endif
 
@@ -390,15 +383,6 @@ void FLASH_Queue_exec( void )
       args.hip[i].clean      = TRUE;
       args.hip[i].request    = FALSE;
    }
-
-   victim = ( FLA_Obj_hip* ) FLA_malloc( n_threads * sizeof( FLA_Obj_hip ) );
-   args.victim = victim;
-
-   for ( i = 0; i < n_threads; i++ )
-      args.victim[i].obj.base = NULL;
-
-   hip_log = ( FLA_Obj_hip* ) FLA_malloc( hip_n_blocks * n_threads * sizeof( FLA_Obj_hip ) );
-   args.hip_log = hip_log;
 #endif
 
    // Initialize tasks with critical information.
@@ -472,8 +456,6 @@ void FLASH_Queue_exec( void )
    FLA_free( hip_lock );
 #endif
    FLA_free( hip );
-   FLA_free( victim );
-   FLA_free( hip_log );
 #endif
 
    // Reset values for next call to FLASH_Queue_exec().
@@ -2238,6 +2220,10 @@ void FLASH_Queue_create_hip( int thread, void *arg )
    // Bind thread to a HIP device
    FLASH_Queue_bind_hip( thread );
 
+#ifdef FLA_ENABLE_MULTITHREADING
+   FLA_RWLock_write_acquire( &(args->hip_lock[thread]) ); // G ***
+#endif
+
    // Allocate the static block cache on device if managed memory is not used
    if ( ! FLASH_Queue_get_malloc_managed_enabled_hip() )
    {
@@ -2254,6 +2240,9 @@ void FLASH_Queue_create_hip( int thread, void *arg )
       for ( i = 0; i < hip_n_blocks; i++ )
          args->hip[thread * hip_n_blocks + i].buffer_hip = (void*) (thread * hip_n_blocks + i);
    }
+#ifdef FLA_ENABLE_MULTITHREADING
+   FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
+#endif
 
    return;
 }
@@ -2279,6 +2268,10 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
    if ( FLASH_Queue_get_malloc_managed_enabled_hip( ) )
       return;
 
+#ifdef FLA_ENABLE_MULTITHREADING
+   FLA_RWLock_read_acquire( &(args->hip_lock[thread]) ); // G ***
+#endif
+
    // Examine every block left on the HIP device.
    for ( i = 0; i < hip_n_blocks; i++ )
    {
@@ -2290,6 +2283,10 @@ void FLASH_Queue_destroy_hip( int thread, void *arg )
       // Free the memory on the HIP for all the blocks.
       FLASH_Queue_free_async_hip( thread, hip_obj.buffer_hip );
    }
+
+#ifdef FLA_ENABLE_MULTITHREADING
+   FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
+#endif
 
    return;
 }
@@ -2346,7 +2343,9 @@ FLA_Bool FLASH_Queue_exec_hip( FLASH_Task *t, void *arg )
       FLA_Bool duplicate;
       FLA_Obj  obj;
 
+#ifdef FLA_ENABLE_HIP_DEBUG
       printf("DEBUG: Task not HIP enabled! Name: %s\n", t->name);
+#endif
 
       // Check the blocks on each HIP device.
       for ( k = 0; k < n_threads; k++ )
@@ -2593,10 +2592,6 @@ FLA_Bool FLASH_Queue_check_block_hip( FLA_Obj obj, int thread, void *arg )
       }
    }
 
-   // Check the victim block.
-   if ( obj.base == args->victim[thread].obj.base )
-      r_val = FALSE;
-
 #ifdef FLA_ENABLE_MULTITHREADING
    FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
 #endif
@@ -2753,7 +2748,8 @@ void FLASH_Queue_update_block_hip( FLA_Obj obj,
       if ( evict_obj.obj.base != NULL && !evict_obj.clean )
       {
          evict = TRUE;
-         args->victim[thread] = evict_obj;
+         // Start async read
+         FLASH_Queue_read_async_hip( thread, evict_obj.obj, evict_obj.buffer_hip );
       }
 
       // Save the block in the data structure.
@@ -2774,24 +2770,15 @@ void FLASH_Queue_update_block_hip( FLA_Obj obj,
    // Place the block on the cache as the most recently used.
    args->hip[thread * hip_n_blocks] = hip_obj;
 
-#ifdef FLA_ENABLE_MULTITHREADING
-   FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
-#endif
-
    // Evict and flush the LRU dirty block.
    if ( evict )
    {
-      FLASH_Queue_read_hip( thread, evict_obj.obj, evict_obj.buffer_hip );
-#ifdef FLA_ENABLE_MULTITHREADING
-      FLA_RWLock_write_acquire( &(args->hip_lock[thread]) ); // G ***
-#endif
-
-      args->victim[thread].obj.base = NULL;
-
-#ifdef FLA_ENABLE_MULTITHREADING
-      FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
-#endif
+      FLASH_Queue_sync_device_hip( thread );
    }
+
+#ifdef FLA_ENABLE_MULTITHREADING
+   FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
+#endif
 
    // Move the block to the HIP device.
    if ( transfer )
@@ -2983,7 +2970,7 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
 ----------------------------------------------------------------------------*/
 {
    FLASH_Queue_vars* args = ( FLASH_Queue_vars* ) arg;
-   int i, k;
+   int k;
    dim_t hip_n_blocks = FLASH_Queue_get_hip_num_blocks();
    int n_transfer = 0;
    FLA_Obj_hip hip_obj;
@@ -2993,7 +2980,7 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
       return;
 
 #ifdef FLA_ENABLE_MULTITHREADING
-   FLA_RWLock_read_acquire( &(args->hip_lock[thread]) ); // G ***
+   FLA_RWLock_write_acquire( &(args->hip_lock[thread]) ); // G ***
 #endif
 
    for ( k = 0; k < hip_n_blocks; k++ )
@@ -3004,64 +2991,18 @@ void FLASH_Queue_flush_hip( int thread, void *arg )
       // Flush the block if it is dirty and requested.
       if ( hip_obj.obj.base != NULL && !hip_obj.clean && hip_obj.request )
       {
-         // Save the block for data transfer outside the critical section.
-         args->hip_log[thread * hip_n_blocks + n_transfer] = hip_obj;
+         // Start async read of block
+         FLASH_Queue_read_async_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
+         // Mark the block as clean - it will be once the device sync completes
+         // and prior to releasing the write lock
+         args->hip[thread * hip_n_blocks + k].clean   = TRUE;
+         args->hip[thread * hip_n_blocks + k].request = FALSE;
          n_transfer++;
       }
    }
 
-#ifdef FLA_ENABLE_MULTITHREADING
-   FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***
-#endif
-
-   // Exit early if a flush is not required.   
-   if ( n_transfer == 0 )
-      return;
-
-   // Flush the block(s) outside the critical section.
-   if ( n_transfer == 1 )
-   {
-      hip_obj = args->hip_log[thread * hip_n_blocks];
-      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
-   }
-   else if ( n_transfer == 2 && !FLASH_Queue_get_malloc_managed_enabled_hip( ) )
-   {
-      // two sync memcpys are faster typically than two async plus device sync
-      hip_obj = args->hip_log[thread * hip_n_blocks];
-      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
-      hip_obj = args->hip_log[thread * hip_n_blocks + 1];
-      FLASH_Queue_read_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
-   }
-   else
-   {
-      for ( i = 0; i < n_transfer; i++ )
-      {
-         hip_obj = args->hip_log[thread * hip_n_blocks + i];
-         FLASH_Queue_read_async_hip( thread, hip_obj.obj, hip_obj.buffer_hip );
-      }
+   if ( n_transfer > 0 )
       FLASH_Queue_sync_device_hip( thread );
-   }
-
-#ifdef FLA_ENABLE_MULTITHREADING
-   FLA_RWLock_write_acquire( &(args->hip_lock[thread]) ); // G ***
-#endif
-
-   // Update the bits for each block that is flushed.
-   for ( i = 0; i < n_transfer; i++ )
-   {
-      // Locate the position of the block on the HIP device.
-      for ( k = 0; k < hip_n_blocks; k++ )
-         if ( args->hip_log[thread * hip_n_blocks + i].obj.base ==
-              args->hip[thread * hip_n_blocks + k].obj.base )
-            break;
-
-      if ( k < hip_n_blocks )
-      {
-         // The block is now clean.
-         args->hip[thread * hip_n_blocks + k].clean   = TRUE;
-         args->hip[thread * hip_n_blocks + k].request = FALSE;
-      }
-   }
 
 #ifdef FLA_ENABLE_MULTITHREADING
    FLA_RWLock_release( &(args->hip_lock[thread]) ); // G ***


### PR DESCRIPTION
Details:
- instead of tracking of to be flushed blocks, kick off async transfers and wait on them afterwards
- similarly, remove the victim block and instead transfer that single block instantly
- add write locking for memory allocations
- add read locking for final flush
- while there, enable managed memory by default (reduces latencies as it eschews cache allocations)